### PR TITLE
[SWM-62] 유저 분석 페이지 출력

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -1,12 +1,16 @@
 package com.swmStrong.demo.domain.categoryPattern.controller;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-//TODO: 계층 구조는 {카테고리}/{패턴} 이기 때문에 계층 구조 생각해서 다시 생각해보기
+
+import java.util.List;
+
 @Tag(name = "카테고리-패턴")
 @RestController
 @RequestMapping("/category")
@@ -49,6 +53,29 @@ public class CategoryPatternController {
     @DeleteMapping("/{category}")
     public ResponseEntity<Void> deletePatternByCategory(@PathVariable String category) {
         categoryPatternService.deleteCategory(category);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "카테고리 조회",
+            description =
+                "<p> 모든 카테고리를 조회한다. </p>" +
+                "<p> 카테고리 내부의 패턴도 조회할 수 있다. </p>"
+    )
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDto>> getAllCategories() {
+        return ResponseEntity.ok(categoryPatternService.getCategories());
+    }
+
+    @Operation(
+            summary = "카테고리 색깔 수정",
+            description =
+                "<p> 카테고리의 색깔을 수정한다. </p>" +
+                "<p> 색깔은 #000000 ~ #FFFFFF 로 입력한다. </p>"
+    )
+    @PatchMapping("/{category}/color")
+    public ResponseEntity<Void> updateCategoryColor(@PathVariable String category, @RequestBody ColorRequestDto colorRequestDto) {
+        categoryPatternService.setCategoryColor(category, colorRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryResponseDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryResponseDto.java
@@ -1,0 +1,19 @@
+package com.swmStrong.demo.domain.categoryPattern.dto;
+
+import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
+
+import java.util.List;
+
+public record CategoryResponseDto(
+        String category,
+        String color,
+        List<String> patterns
+) {
+    public static CategoryResponseDto from(CategoryPattern categoryPattern) {
+        return new CategoryResponseDto(
+                categoryPattern.getCategory(),
+                categoryPattern.getColor(),
+                categoryPattern.getPatterns()
+        );
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/ColorRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/ColorRequestDto.java
@@ -1,0 +1,6 @@
+package com.swmStrong.demo.domain.categoryPattern.dto;
+
+public record ColorRequestDto(
+        String color
+) {
+}

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
@@ -17,4 +17,9 @@ public class CategoryPattern {
 
     private String category;
     private List<String> patterns;
+    private String color;
+
+    public void setColor(String color) {
+        this.color = color;
+    }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
@@ -4,7 +4,10 @@ package com.swmStrong.demo.domain.categoryPattern.repository;
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface CategoryPatternRepository extends MongoRepository<CategoryPattern, String> {
     boolean existsByCategory(String category);
     void deletePatternCategoryByCategory(String category);
+    Optional<CategoryPattern> findByCategory(String category);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
@@ -1,9 +1,15 @@
 package com.swmStrong.demo.domain.categoryPattern.service;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
+
+import java.util.List;
 
 public interface CategoryPatternService {
     void addPattern(String category, PatternRequestDto patternRequestDto);
     void deletePatternByCategory(String category, PatternRequestDto patternRequestDto);
     void deleteCategory(String category);
+    List<CategoryResponseDto> getCategories();
+    void setCategoryColor(String category, ColorRequestDto colorRequestDto);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -1,11 +1,15 @@
 package com.swmStrong.demo.domain.categoryPattern.service;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.matcher.core.PatternMatcher;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
 import com.swmStrong.demo.domain.categoryPattern.repository.CustomCategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class CategoryPatternServiceImpl implements CategoryPatternService {
@@ -49,6 +53,24 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
         }
         categoryPatternRepository.deletePatternCategoryByCategory(category);
         patternMatcher.init();
+    }
+
+    @Override
+    public List<CategoryResponseDto> getCategories() {
+        List<CategoryPattern> categoryPatterns = categoryPatternRepository.findAll();
+        return categoryPatterns.stream()
+                .map(CategoryResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    public void setCategoryColor(String category, ColorRequestDto colorRequestDto) {
+        CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
+                .orElseThrow(IllegalArgumentException::new);
+
+        categoryPattern.setColor(colorRequestDto.color());
+
+        categoryPatternRepository.save(categoryPattern);
     }
 
     private void addCategory(String category) {

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import java.util.Set;
 
 public interface LeaderboardRepository {
-    void increaseScoreByUserId(String key, String userId, long seconds);
+    void increaseScoreByUserId(String key, String userId, double seconds);
     Set<ZSetOperations.TypedTuple<String>> getTopUsers(String key, int topN);
     Long getRankByUserId(String key, String userId);
     Double getScoreByUserId(String key, String userId);

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepositoryImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepositoryImpl.java
@@ -16,7 +16,7 @@ public class LeaderboardRepositoryImpl implements LeaderboardRepository {
     }
 
     @Override
-    public void increaseScoreByUserId(String key, String userId, long seconds) {
+    public void increaseScoreByUserId(String key, String userId, double seconds) {
         stringRedisTemplate.opsForZSet().incrementScore(key, userId, seconds);
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface LeaderboardService {
-    void increaseScore(String category, String userId, long duration);
+    void increaseScore(String category, String userId, double duration);
     List<LeaderboardResponseDto> getTopUsers(String category, int topN);
     Optional<LeaderboardResponseDto> getUserScoreInfo(String category, String userId);
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -24,7 +24,7 @@ public class LeaderboardServiceImpl implements LeaderboardService {
     }
 
     @Override
-    public void increaseScore(String category, String userId, long duration) {
+    public void increaseScore(String category, String userId, double duration) {
         String key = generateKey(category);
         log.info("Increase score for user {} to {}", userId, duration);
         leaderboardRepository.increaseScoreByUserId(key, userId, duration);

--- a/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
+++ b/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
@@ -101,9 +101,11 @@ public class PatternMatcher {
                 now = now.children.get(c);
             }
 
-            Node temp = now ;
+            Node temp = now;
             while (temp != this.root) {
-                matchedCategories.addAll(temp.categories);
+                if (!temp.categories.isEmpty()) {
+                    matchedCategories.addAll(temp.categories);
+                }
                 temp = temp.fail;
             }
         }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.usageLog.controller;
 
+import com.swmStrong.demo.domain.usageLog.dto.CategoryUsageDto;
 import com.swmStrong.demo.domain.usageLog.dto.SaveUsageLogDto;
 import com.swmStrong.demo.domain.usageLog.dto.UsageLogResponseDto;
 import com.swmStrong.demo.domain.usageLog.service.UsageLogService;
@@ -34,7 +35,7 @@ public class UsageLogController {
     }
 
     @Operation(
-            summary = "유저 사용 로그 저장",
+            summary = "유저 사용 로그 조회",
             description =
                 "<p> 유저의 전체 사용 로그를 조회한다. </p>" +
                 "<p> 정리되지 않은 로우 데이터를 반환한다. </p>"
@@ -42,5 +43,16 @@ public class UsageLogController {
     @GetMapping
     public ResponseEntity<List<UsageLogResponseDto>> getUsageLogById(@RequestParam String userId) {
         return ResponseEntity.ok(usageLogService.getUsageLogByUserId(userId));
+    }
+
+    @Operation(
+            summary = "유저 사용 로그 조회(당일)",
+            description =
+                "<p> 유저의 당일 사용 로그를 조회한다. </p>" +
+                "<p> 정리가 되어 있다. </p>"
+    )
+    @GetMapping("/today")
+    public ResponseEntity<List<CategoryUsageDto>> getUsageLogByIdToday(@RequestParam String userId) {
+        return ResponseEntity.ok(usageLogService.getUsageLogByUserIdToday(userId));
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/dto/CategoryUsageDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/dto/CategoryUsageDto.java
@@ -1,0 +1,8 @@
+package com.swmStrong.demo.domain.usageLog.dto;
+
+public record CategoryUsageDto(
+        String category,
+        long duration,
+        String color
+) {
+}

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/dto/CategoryUsageDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/dto/CategoryUsageDto.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.usageLog.dto;
 
 public record CategoryUsageDto(
         String category,
-        long duration,
+        double duration,
         String color
 ) {
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/dto/SaveUsageLogDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/dto/SaveUsageLogDto.java
@@ -6,7 +6,7 @@ public record SaveUsageLogDto(
         String userId,
         String title,
         String app,
-        long duration,
+        double duration,
         LocalDateTime timestamp
 ) {
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/dto/UsageLogRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/dto/UsageLogRequestDto.java
@@ -1,6 +1,0 @@
-package com.swmStrong.demo.domain.usageLog.dto;
-
-public record UsageLogRequestDto(
-        String id
-) {
-}

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/dto/UsageLogResponseDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/dto/UsageLogResponseDto.java
@@ -8,7 +8,7 @@ public record UsageLogResponseDto(
         String userId,
         String title,
         String app,
-        long duration,
+        double duration,
         LocalDateTime timestamp
 ) {
     public static UsageLogResponseDto from(UsageLog usageLog) {

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/entity/UsageLog.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/entity/UsageLog.java
@@ -18,13 +18,13 @@ public class UsageLog {
 
     private String userId;
     private LocalDateTime timestamp;
-    private long duration;
+    private double duration;
     private String app;
     private String title;
     private Set<String> categories;
 
     @Builder
-    public UsageLog(String userId, LocalDateTime timestamp, long duration, String app, String title, Set<String> categories) {
+    public UsageLog(String userId, LocalDateTime timestamp, double duration, String app, String title, Set<String> categories) {
         this.userId = userId;
         this.timestamp = timestamp;
         this.duration = duration;

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogService.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogService.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.usageLog.service;
 
+import com.swmStrong.demo.domain.usageLog.dto.CategoryUsageDto;
 import com.swmStrong.demo.domain.usageLog.dto.SaveUsageLogDto;
 import com.swmStrong.demo.domain.usageLog.dto.UsageLogResponseDto;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface UsageLogService {
     void saveAll(List<SaveUsageLogDto> saveUsageLogDtoList);
     List<UsageLogResponseDto> getUsageLogByUserId(String userId);
+    List<CategoryUsageDto> getUsageLogByUserIdToday(String userId);
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
@@ -1,6 +1,7 @@
 package com.swmStrong.demo.domain.usageLog.service;
 
 import com.swmStrong.demo.domain.matcher.core.PatternMatcher;
+import com.swmStrong.demo.domain.usageLog.dto.CategoryUsageDto;
 import com.swmStrong.demo.domain.usageLog.dto.SaveUsageLogDto;
 import com.swmStrong.demo.domain.usageLog.dto.UsageLogResponseDto;
 import com.swmStrong.demo.domain.usageLog.entity.UsageLog;
@@ -10,6 +11,8 @@ import com.swmStrong.demo.infra.redis.StreamConfig;
 import com.swmStrong.demo.message.dto.LeaderBoardUsageMessage;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -67,5 +70,14 @@ public class UsageLogServiceImpl implements UsageLogService {
         List<UsageLog> usageLogs = usageLogRepository.findByUserId(userId);
 
         return usageLogs.stream().map(UsageLogResponseDto::from).toList();
+    }
+
+    @Override
+    public List<CategoryUsageDto> getUsageLogByUserIdToday(String userId) {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+        List<CategoryUsageDto> usageLogs = usageLogRepository.findByUserIdAndTimestampBetween(userId, start, end);
+        System.out.println(usageLogs.toString());
+        return usageLogs;
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
@@ -76,8 +76,6 @@ public class UsageLogServiceImpl implements UsageLogService {
     public List<CategoryUsageDto> getUsageLogByUserIdToday(String userId) {
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = start.plusDays(1);
-        List<CategoryUsageDto> usageLogs = usageLogRepository.findByUserIdAndTimestampBetween(userId, start, end);
-        System.out.println(usageLogs.toString());
-        return usageLogs;
+        return usageLogRepository.findByUserIdAndTimestampBetween(userId, start, end);
     }
 }

--- a/src/main/java/com/swmStrong/demo/message/dto/LeaderBoardUsageMessage.java
+++ b/src/main/java/com/swmStrong/demo/message/dto/LeaderBoardUsageMessage.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record LeaderBoardUsageMessage(
         String userId,
         String category,
-        long duration,
+        double duration,
         LocalDateTime timestamp
 ) {
 }


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [ ] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- 카테고리 스키마 내부에서 색상을 관리해 동적으로 적용할 수 있도록 했습니다.
- 유저의 당일 사용량을 반환하는 API를 만들었습니다.  

05/23 11:30 추가
- duration 타입을 통일했습니다.
---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 기존 CategoryPattern Entity에서 color 속성을 넣었습니다.
- CategoryPattern <-> UsageLog 간 조인이 필요해 Repository 내부 Aggregation을 통해 해결했습니다. 

05/23 11:30 추가
- duration 타입이 long, double 로 나누어져 있는데 클라이언트에서 double 로 들어오는 것을 고려해 double 로 모두 통일했습니다.
---

## ⏰ 리뷰 시간 예상

약 10분 정도 예상됩니다.
---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

- 출력 타입은 다음 이슈로 넘기겠습니다.

05/23 11:30 추가
- 출력 타입을 해결한 커밋을 추가했습니다.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.
<img width="539" alt="스크린샷 2025-05-23 00 34 56" src="https://github.com/user-attachments/assets/89ac2ac7-371e-456d-b327-908fa526ef39" />

---

## 🔗 관련 이슈

#5 유저 분석 페이지 출력
#8 duration 타입 통일