### PR TITLE
[SWM-68] 카테고리-패턴 관련 CRUD 구체화

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -57,10 +57,21 @@ public class CategoryPatternController {
     }
 
     @Operation(
-            summary = "카테고리 조회",
+            summary = "해당 카테고리 조회",
+            description =
+                "<p> 카테고리 이름에 맞는 카테고리를 조회한다. </p>" +
+                "<p> 카테고리 내부의 패턴도 함께 출력된다. </p>"
+    )
+    @GetMapping("/{category}")
+    public ResponseEntity<CategoryResponseDto> getCategoryByCategory(@PathVariable String category) {
+        return ResponseEntity.ok(categoryPatternService.getCategoryByCategory(category));
+    }
+
+    @Operation(
+            summary = "카테고리 전체 조회",
             description =
                 "<p> 모든 카테고리를 조회한다. </p>" +
-                "<p> 카테고리 내부의 패턴도 조회할 수 있다. </p>"
+                "<p> 카테고리 내부의 패턴도 함께 출력된다. </p>"
     )
     @GetMapping
     public ResponseEntity<List<CategoryResponseDto>> getAllCategories() {

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.categoryPattern.controller;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
@@ -76,6 +77,12 @@ public class CategoryPatternController {
     @PatchMapping("/{category}/color")
     public ResponseEntity<Void> updateCategoryColor(@PathVariable String category, @RequestBody ColorRequestDto colorRequestDto) {
         categoryPatternService.setCategoryColor(category, colorRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addCategory(@RequestBody CategoryRequestDto categoryRequestDto) {
+        categoryPatternService.addCategory(categoryRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -26,8 +26,7 @@ public class CategoryPatternController {
     @Operation(
             summary = "패턴 추가",
             description =
-                "<p> 패턴을 추가한다. </p>" +
-                "<p> 추가하려는 카테고리가 없다면 자동 생성된다.</p>"
+                "<p> 카테고리에 해당하는 패턴을 추가한다. </p>"
     )
     @PostMapping("/{category}")
     public ResponseEntity<Void> addPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
@@ -37,7 +36,7 @@ public class CategoryPatternController {
 
     @Operation(
             summary = "패턴 삭제",
-            description = "<p> 패턴을 삭제한다. </p>"
+            description = "<p> 카테고리 안에 있는 패턴을 삭제한다. </p>"
     )
     @DeleteMapping("/{category}/pattern")
     public ResponseEntity<Void> deletePatternByCategoryAndPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
@@ -80,6 +79,11 @@ public class CategoryPatternController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "카테고리 추가",
+            description =
+                "<p> 카테고리를 추가한다. </p>"
+    )
     @PostMapping
     public ResponseEntity<Void> addCategory(@RequestBody CategoryRequestDto categoryRequestDto) {
         categoryPatternService.addCategory(categoryRequestDto);

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.categoryPattern.controller;
 
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
-import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.UpdateCategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -79,14 +79,15 @@ public class CategoryPatternController {
     }
 
     @Operation(
-            summary = "카테고리 색깔 수정",
+            summary = "카테고리 수정",
             description =
-                "<p> 카테고리의 색깔을 수정한다. </p>" +
-                "<p> 색깔은 #000000 ~ #FFFFFF 로 입력한다. </p>"
+                "<p> 카테고리의 이름과 색깔을 수정한다. </p>" +
+                "<p> 색깔은 #000000 ~ #FFFFFF 로 입력한다. </p>" +
+                "<p> 필요한 부분만 입력하고, 나머지는 비워둬도 된다. </p>"
     )
-    @PatchMapping("/{category}/color")
-    public ResponseEntity<Void> updateCategoryColor(@PathVariable String category, @RequestBody ColorRequestDto colorRequestDto) {
-        categoryPatternService.setCategoryColor(category, colorRequestDto);
+    @PatchMapping("/{category}")
+    public ResponseEntity<Void> updateCategory(@PathVariable String category, @RequestBody UpdateCategoryRequestDto updateCategoryRequestDto) {
+        categoryPatternService.updateCategory(category, updateCategoryRequestDto);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryRequestDto.java
@@ -1,0 +1,7 @@
+package com.swmStrong.demo.domain.categoryPattern.dto;
+
+public record CategoryRequestDto(
+        String category,
+        String color
+) {
+}

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryResponseDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryResponseDto.java
@@ -2,12 +2,12 @@ package com.swmStrong.demo.domain.categoryPattern.dto;
 
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
 
-import java.util.List;
+import java.util.Set;
 
 public record CategoryResponseDto(
         String category,
         String color,
-        List<String> patterns
+        Set<String> patterns
 ) {
     public static CategoryResponseDto from(CategoryPattern categoryPattern) {
         return new CategoryResponseDto(

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/UpdateCategoryRequestDto.java
@@ -1,6 +1,7 @@
 package com.swmStrong.demo.domain.categoryPattern.dto;
 
-public record ColorRequestDto(
+public record UpdateCategoryRequestDto(
+        String category,
         String color
 ) {
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Id;
 import lombok.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.List;
+import java.util.Set;
 
 @Document(collection = "category_pattern")
 @Getter
@@ -16,8 +16,12 @@ public class CategoryPattern {
     private String id;
 
     private String category;
-    private List<String> patterns;
+    private Set<String> patterns;
     private String color;
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
 
     public void setColor(String color) {
         this.color = color;

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
@@ -12,6 +12,7 @@ public interface CategoryPatternService {
     void addPattern(String category, PatternRequestDto patternRequestDto);
     void deletePatternByCategory(String category, PatternRequestDto patternRequestDto);
     void deleteCategory(String category);
+    CategoryResponseDto getCategoryByCategory(String category);
     List<CategoryResponseDto> getCategories();
     void setCategoryColor(String category, ColorRequestDto colorRequestDto);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.categoryPattern.service;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
@@ -7,6 +8,7 @@ import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import java.util.List;
 
 public interface CategoryPatternService {
+    void addCategory(CategoryRequestDto categoryRequestDto);
     void addPattern(String category, PatternRequestDto patternRequestDto);
     void deletePatternByCategory(String category, PatternRequestDto patternRequestDto);
     void deleteCategory(String category);

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternService.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.categoryPattern.service;
 
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
-import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.UpdateCategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 
 import java.util.List;
@@ -14,5 +14,5 @@ public interface CategoryPatternService {
     void deleteCategory(String category);
     CategoryResponseDto getCategoryByCategory(String category);
     List<CategoryResponseDto> getCategories();
-    void setCategoryColor(String category, ColorRequestDto colorRequestDto);
+    void updateCategory(String category, UpdateCategoryRequestDto updateCategoryRequestDto);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -57,9 +57,13 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
     @Override
     public void deletePatternByCategory(String category, PatternRequestDto patternRequestDto) {
-        if (!categoryPatternRepository.existsByCategory(category)) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리");
+        CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
+                .orElseThrow(IllegalArgumentException::new);
+
+        if (!categoryPattern.getPatterns().contains(patternRequestDto.pattern())) {
+            throw new IllegalArgumentException("존재하지 않는 패턴");
         }
+
         customCategoryPatternRepository.removePattern(category, patternRequestDto.pattern());
         patternMatcher.init();
     }
@@ -77,7 +81,6 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
     public CategoryResponseDto getCategoryByCategory(String category) {
         CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
                 .orElseThrow(IllegalArgumentException::new);
-
         return CategoryResponseDto.from(categoryPattern);
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -99,6 +99,7 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
         if (updateCategoryRequestDto.category() != null) {
             categoryPattern.setCategory(updateCategoryRequestDto.category());
+            patternMatcher.init();
         }
         if (updateCategoryRequestDto.color() != null) {
             categoryPattern.setColor(updateCategoryRequestDto.color());

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.categoryPattern.service;
 
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
-import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
+import com.swmStrong.demo.domain.categoryPattern.dto.UpdateCategoryRequestDto;
 import com.swmStrong.demo.domain.matcher.core.PatternMatcher;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
@@ -90,12 +90,18 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
     }
 
     @Override
-    public void setCategoryColor(String category, ColorRequestDto colorRequestDto) {
+    public void updateCategory(String category, UpdateCategoryRequestDto updateCategoryRequestDto) {
         CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
                 .orElseThrow(IllegalArgumentException::new);
 
-        categoryPattern.setColor(colorRequestDto.color());
+        if (updateCategoryRequestDto.category() != null) {
+            categoryPattern.setCategory(updateCategoryRequestDto.category());
+        }
+        if (updateCategoryRequestDto.color() != null) {
+            categoryPattern.setColor(updateCategoryRequestDto.color());
+        }
 
         categoryPatternRepository.save(categoryPattern);
     }
+
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.categoryPattern.service;
 
+import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.ColorRequestDto;
 import com.swmStrong.demo.domain.matcher.core.PatternMatcher;
@@ -29,10 +30,27 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
     }
 
     @Override
+    public void addCategory(CategoryRequestDto categoryRequestDto) {
+        if (categoryPatternRepository.existsByCategory(categoryRequestDto.category())) {
+            throw new IllegalArgumentException("이미 존재하는 카테고리");
+        }
+
+        //TODO: 색깔에 대한 정규표현식 만들어두기 (#000000 - #FFFFFF)
+
+        CategoryPattern categoryPattern = CategoryPattern.builder()
+                .category(categoryRequestDto.category())
+                .color(categoryRequestDto.color())
+                .build();
+
+        categoryPatternRepository.save(categoryPattern);
+    }
+
+    @Override
     public void addPattern(String category, PatternRequestDto patternRequestDto) {
         if (!categoryPatternRepository.existsByCategory(category)) {
-            addCategory(category);
+            throw new IllegalArgumentException("존재하지 않는 카테고리");
         }
+
         customCategoryPatternRepository.addPattern(category, patternRequestDto.pattern());
         patternMatcher.insert(patternRequestDto.pattern(), category);
     }
@@ -70,16 +88,6 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
         categoryPattern.setColor(colorRequestDto.color());
 
-        categoryPatternRepository.save(categoryPattern);
-    }
-
-    private void addCategory(String category) {
-        if (categoryPatternRepository.existsByCategory(category)) {
-            return;
-        }
-        CategoryPattern categoryPattern = CategoryPattern.builder()
-                .category(category)
-                .build();
         categoryPatternRepository.save(categoryPattern);
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -74,6 +74,14 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
     }
 
     @Override
+    public CategoryResponseDto getCategoryByCategory(String category) {
+        CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
+                .orElseThrow(IllegalArgumentException::new);
+
+        return CategoryResponseDto.from(categoryPattern);
+    }
+
+    @Override
     public List<CategoryResponseDto> getCategories() {
         List<CategoryPattern> categoryPatterns = categoryPatternRepository.findAll();
         return categoryPatterns.stream()


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [x] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

카테고리-패턴 관련 CRUD 구체화

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 카테고리 단독 추가 (현재는 패턴과 카테고리를 입력하면 카테고리를 만들거나 카테고리가 있는 경우 합침)

- 패턴 중복 관리 (List<> 형태로 패턴이 관리되고 있어, 중복 관리가 어려움)

- 카테고리 이름 변경 (카테고리에 속한 패턴은 유지한 채로, 카테고리의 이름을 변경해야할 가능성이 있음)

- 그 외에 조건에 따른 실패로직 처리 (패턴이 없는데 해당 패턴을 삭제해달라거나, 카테고리가 없는 경우 패턴을 만들지 못하도록 강제)

---

## ⏰ 리뷰 시간 예상

약 10분 정도 예상합니다. 

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

색 지정 관련 정규표현식을 만드려고 했는데, valid annotation으로 작업하는 게 나을 것 같아 일단 후순위로 미뤘습니다.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#10 카테고리-패턴 관련 CRUD 구체화
