### PR TITLE
[SWM-78] 유저 닉네임 표시 및 패턴 중복 등록 해결

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryPatternJSONDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryPatternJSONDto.java
@@ -3,6 +3,7 @@ package com.swmStrong.demo.domain.categoryPattern.dto;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 public class CategoryPatternJSONDto {
@@ -12,6 +13,6 @@ public class CategoryPatternJSONDto {
     public static class CategoryPatternEntry {
         private String category;
         private String color;
-        private List<String> patterns;
+        private Set<String> patterns;
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
@@ -3,19 +3,28 @@ package com.swmStrong.demo.domain.categoryPattern.initializer;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryPatternJSONDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
+import com.swmStrong.demo.domain.categoryPattern.repository.CustomCategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import com.swmStrong.demo.infra.json.JsonLoader;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+
 @Component
 public class CategoryPatternInitializer implements SmartInitializingSingleton {
 
     private final CategoryPatternService categoryPatternService;
+    private final CustomCategoryPatternRepository customCategoryPatternRepository;
     private final JsonLoader jsonLoader;
 
-    public CategoryPatternInitializer(CategoryPatternService categoryPatternService, JsonLoader jsonLoader) {
+    public CategoryPatternInitializer(
+            CategoryPatternService categoryPatternService,
+            CustomCategoryPatternRepository customCategoryPatternRepository,
+            JsonLoader jsonLoader
+    ) {
         this.categoryPatternService = categoryPatternService;
+        this.customCategoryPatternRepository = customCategoryPatternRepository;
         this.jsonLoader = jsonLoader;
     }
 
@@ -30,7 +39,10 @@ public class CategoryPatternInitializer implements SmartInitializingSingleton {
             if (!categoryPatternService.existsByCategory(entry.getCategory())) {
                 categoryPatternService.addCategory(CategoryRequestDto.of(entry.getCategory(), entry.getColor()));
             }
-            for (String pattern: entry.getPatterns()) {
+
+            Set<String> newPatterns = entry.getPatterns();
+            newPatterns.removeAll(customCategoryPatternRepository.findPatternsByCategory(entry.getCategory()));
+            for (String pattern: newPatterns) {
                 categoryPatternService.addPattern(entry.getCategory(), PatternRequestDto.of(pattern));
             }
         }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CustomCategoryPatternRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CustomCategoryPatternRepository.java
@@ -1,7 +1,10 @@
 package com.swmStrong.demo.domain.categoryPattern.repository;
 
 
+import java.util.Set;
+
 public interface CustomCategoryPatternRepository {
     void addPattern(String category, String newPattern);
     void removePattern(String category, String pattern);
+    Set<String> findPatternsByCategory(String category);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CustomCategoryPatternRepositoryImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CustomCategoryPatternRepositoryImpl.java
@@ -8,6 +8,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Repository
 public class CustomCategoryPatternRepositoryImpl implements CustomCategoryPatternRepository {
     private final MongoTemplate mongoTemplate;
@@ -28,5 +31,19 @@ public class CustomCategoryPatternRepositoryImpl implements CustomCategoryPatter
         Query query = new Query(Criteria.where("category").is(category));
         Update update = new Update().pull("patterns", pattern);
         mongoTemplate.updateFirst(query, update, CategoryPattern.class);
+    }
+
+    @Override
+    public Set<String> findPatternsByCategory(String category) {
+        Query query = new Query(Criteria.where("category").is(category));
+        query.fields().include("patterns");
+
+        CategoryPattern result = mongoTemplate.findOne(query, CategoryPattern.class);
+
+        if (result != null && result.getPatterns() != null) {
+            return new HashSet<>(result.getPatterns());
+        } else {
+            return new HashSet<>();
+        }
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Tag(name = "리더보드")
 @RestController

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/dto/LeaderboardResponseDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/dto/LeaderboardResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record LeaderboardResponseDto(
         String userId,
+        String nickname,
         double score,
         long rank
 ) {

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -2,6 +2,7 @@ package com.swmStrong.demo.domain.leaderboard.service;
 
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardRepository;
+import com.swmStrong.demo.domain.user.facade.UserInfoProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -18,11 +19,13 @@ import java.util.Set;
 public class LeaderboardServiceImpl implements LeaderboardService {
 
     private final LeaderboardRepository leaderboardRepository;
+    private final UserInfoProvider userInfoProvider;
 
     private static final String LEADERBOARD_KEY_PREFIX = "leaderboard:";
 
-    public LeaderboardServiceImpl(LeaderboardRepository leaderboardRepository) {
+    public LeaderboardServiceImpl(LeaderboardRepository leaderboardRepository, UserInfoProvider userInfoProvider) {
         this.leaderboardRepository = leaderboardRepository;
+        this.userInfoProvider = userInfoProvider;
     }
 
     @Override
@@ -50,6 +53,7 @@ public class LeaderboardServiceImpl implements LeaderboardService {
             response.add(
                     LeaderboardResponseDto.builder()
                             .userId(userId)
+                            .nickname(userInfoProvider.getNicknameByUserId(userId))
                             .score(score)
                             .rank(rank++)
                             .build()

--- a/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
@@ -20,7 +20,7 @@ public class UserController {
 
     @PostMapping()
     public ResponseEntity<ApiResponse<Void>> createGuestUser(@RequestBody UserRequestDto userRequestDto) {
-        userService.registerGuestNickname(userRequestDto.deviceId(), userRequestDto.nickname());
+        userService.registerGuestNickname(userRequestDto.userId(), userRequestDto.nickname());
         return ResponseEntity
                 .status(SuccessCode._CREATED.getHttpStatus())
                 .body(ApiResponse.success(SuccessCode._CREATED, null));

--- a/src/main/java/com/swmStrong/demo/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/dto/UserRequestDto.java
@@ -1,7 +1,7 @@
 package com.swmStrong.demo.domain.user.dto;
 
 public record UserRequestDto(
-        String deviceId,
+        String userId,
         String nickname
 ) {
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/entity/User.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/entity/User.java
@@ -5,18 +5,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.*;
 
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class User extends BaseEntity {
-
     @Id
-    @Builder.Default
-    private String id = UUID.randomUUID().toString();
-    private String deviceId;
+    private String id;
     private String nickname;
+
+    @Builder
+    public User(String id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
@@ -1,0 +1,5 @@
+package com.swmStrong.demo.domain.user.facade;
+
+public interface UserInfoProvider {
+    String getNicknameByUserId(String userId);
+}

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProviderImpl.java
@@ -1,0 +1,22 @@
+package com.swmStrong.demo.domain.user.facade;
+
+import com.swmStrong.demo.domain.user.entity.User;
+import com.swmStrong.demo.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserInfoProviderImpl implements UserInfoProvider {
+
+    private final UserRepository userRepository;
+
+    public UserInfoProviderImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public String getNicknameByUserId(String userId) {
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .orElse("Unknown");
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/repository/UserRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, String> {
     Boolean existsByNickname(String nickname);
-    Boolean existsByDeviceId(String deviceId);
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/service/UserService.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/service/UserService.java
@@ -1,10 +1,7 @@
 package com.swmStrong.demo.domain.user.service;
 
-import com.swmStrong.demo.domain.user.entity.User;
-import org.springframework.stereotype.Service;
-
 public interface UserService {
-    public void registerGuestNickname(String deviceId, String nickname);
-    public boolean isGuestRegistered(String deviceId);
-    public boolean isGuestNicknameDuplicated(String nickname);
+    void registerGuestNickname(String userId, String nickname);
+    boolean isGuestRegistered(String userId);
+    boolean isGuestNicknameDuplicated(String nickname);
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
@@ -12,24 +12,25 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
-    public void registerGuestNickname(String deviceId, String nickname) {
+    public void registerGuestNickname(String userId, String nickname) {
 
         if (userRepository.existsByNickname(nickname)){
             throw new ApiException(ErrorCode.DUPLICATE_NICKNAME);
         }
-        if (userRepository.existsByDeviceId(deviceId)){
+        if (userRepository.existsById(userId)){
             throw new ApiException(ErrorCode.DUPLICATE_DEVICE_ID);
         }
+
         User user = User.builder()
-                .deviceId(deviceId)
+                .id(userId)
                 .nickname(nickname)
                 .build();
 
         userRepository.save(user);
     }
 
-    public boolean isGuestRegistered(String deviceId) {
-        return userRepository.existsByDeviceId(deviceId);
+    public boolean isGuestRegistered(String userId) {
+        return userRepository.existsById(userId);
     }
 
     public boolean isGuestNicknameDuplicated(String nickname) {


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [x] 코드 수정
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- 유저 닉네임 반환
- 패턴 중복 등록 해결
---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 유저 닉네임 반환을 위해 facade 패턴을 사용했습니다
- 패턴 중복 등록 해결을 위해 dto에서 set으로 받아 set method 를 통해 중복 처리 후 등록 했습니다. 
- 유저 관련 entity를 수정하면서 userId 로 변수명과 함수명을 통일했습니다.
---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

약 10분 정도 예상됩니다. 
---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

entity 수정과 관련하여 DB에서도 처리가 필요합니다.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#22 클라이언트 요구사항 ( 유저 닉네임 표시 )
#23 카테고리-패턴 설정으로 인해 PatternMatcher가 중복 실행 