### PR TITLE
[SWM-81] 리더 보드 전체 조회 및 category 관련 버그 수정

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProvider.java
@@ -1,0 +1,7 @@
+package com.swmStrong.demo.domain.categoryPattern.facade;
+
+import java.util.List;
+
+public interface CategoryProvider {
+    List<String> getCategories();
+}

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProviderImpl.java
@@ -1,0 +1,24 @@
+package com.swmStrong.demo.domain.categoryPattern.facade;
+
+import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
+import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryProviderImpl implements CategoryProvider {
+
+    private final CategoryPatternRepository categoryPatternRepository;
+
+    public CategoryProviderImpl(CategoryPatternRepository categoryPatternRepository) {
+        this.categoryPatternRepository = categoryPatternRepository;
+    }
+
+    @Override
+    public List<String> getCategories() {
+        return categoryPatternRepository.findAll().stream()
+                .map(CategoryPattern::getCategory)
+                .toList();
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
@@ -3,6 +3,7 @@ package com.swmStrong.demo.domain.categoryPattern.initializer;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryPatternJSONDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
+import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.repository.CustomCategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import com.swmStrong.demo.infra.json.JsonLoader;
@@ -15,16 +16,16 @@ import java.util.Set;
 public class CategoryPatternInitializer implements SmartInitializingSingleton {
 
     private final CategoryPatternService categoryPatternService;
-    private final CustomCategoryPatternRepository customCategoryPatternRepository;
+    private final CategoryPatternRepository categoryPatternRepository;
     private final JsonLoader jsonLoader;
 
     public CategoryPatternInitializer(
             CategoryPatternService categoryPatternService,
-            CustomCategoryPatternRepository customCategoryPatternRepository,
+            CategoryPatternRepository categoryPatternRepository,
             JsonLoader jsonLoader
     ) {
         this.categoryPatternService = categoryPatternService;
-        this.customCategoryPatternRepository = customCategoryPatternRepository;
+        this.categoryPatternRepository = categoryPatternRepository;
         this.jsonLoader = jsonLoader;
     }
 
@@ -41,7 +42,7 @@ public class CategoryPatternInitializer implements SmartInitializingSingleton {
             }
 
             Set<String> newPatterns = entry.getPatterns();
-            newPatterns.removeAll(customCategoryPatternRepository.findPatternsByCategory(entry.getCategory()));
+            newPatterns.removeAll(categoryPatternRepository.findPatternsByCategory(entry.getCategory()));
             for (String pattern: newPatterns) {
                 categoryPatternService.addPattern(entry.getCategory(), PatternRequestDto.of(pattern));
             }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface CategoryPatternRepository extends MongoRepository<CategoryPattern, String> {
+public interface CategoryPatternRepository extends MongoRepository<CategoryPattern, String>, CustomCategoryPatternRepository {
     boolean existsByCategory(String category);
     void deletePatternCategoryByCategory(String category);
     Optional<CategoryPattern> findByCategory(String category);

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -6,7 +6,6 @@ import com.swmStrong.demo.domain.categoryPattern.dto.UpdateCategoryRequestDto;
 import com.swmStrong.demo.domain.matcher.core.PatternMatcher;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
-import com.swmStrong.demo.domain.categoryPattern.repository.CustomCategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
 import org.springframework.stereotype.Service;
 
@@ -16,16 +15,13 @@ import java.util.List;
 public class CategoryPatternServiceImpl implements CategoryPatternService {
 
     private final CategoryPatternRepository categoryPatternRepository;
-    private final CustomCategoryPatternRepository customCategoryPatternRepository;
     private final PatternMatcher patternMatcher;
 
     public CategoryPatternServiceImpl(
             CategoryPatternRepository categoryPatternRepository,
-            CustomCategoryPatternRepository customCategoryPatternRepository,
             PatternMatcher patternMatcher
     ) {
         this.categoryPatternRepository = categoryPatternRepository;
-        this.customCategoryPatternRepository = customCategoryPatternRepository;
         this.patternMatcher = patternMatcher;
     }
 
@@ -51,7 +47,7 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
             throw new IllegalArgumentException("존재하지 않는 카테고리");
         }
 
-        customCategoryPatternRepository.addPattern(category, patternRequestDto.pattern());
+        categoryPatternRepository.addPattern(category, patternRequestDto.pattern());
         patternMatcher.insert(patternRequestDto.pattern(), category);
     }
 
@@ -64,7 +60,7 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
             throw new IllegalArgumentException("존재하지 않는 패턴");
         }
 
-        customCategoryPatternRepository.removePattern(category, patternRequestDto.pattern());
+        categoryPatternRepository.removePattern(category, patternRequestDto.pattern());
         patternMatcher.init();
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
@@ -41,6 +41,12 @@ public class LeaderboardController {
         return ResponseEntity.ok(leaderboardService.getLeaderboardPage(category, page, size, date));
     }
 
+    @Operation(
+            summary = "카테고리의 모든 유저 조회",
+            description =
+                "<p> 카테고리별로, 모든 유저의 점수, 순위를 출력한다. </p>" +
+                "<p> 페이징 없는 버전이다. </p>"
+    )
     @GetMapping("/{category}/all")
     public ResponseEntity<List<LeaderboardResponseDto>> getUsersByCategory(
             @PathVariable String category,
@@ -70,6 +76,12 @@ public class LeaderboardController {
         return ResponseEntity.ok(leaderboardService.getUserScoreInfo(category, userId, date));
     }
 
+    @Operation(
+            summary = "전체 카테고리 10등까지 조회",
+            description =
+                "<p> 전체 카테고리의 1등부터 10등까지 조회한다. </p>" +
+                "<p> 일단 당일만 조회 가능하다. </p>"
+    )
     @GetMapping("/top-users")
     public ResponseEntity<Map<String, List<LeaderboardResponseDto>>> getLeaderboards() {
         return ResponseEntity.ok(leaderboardService.getLeaderboards());

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "리더보드")
 @RestController
@@ -40,6 +41,16 @@ public class LeaderboardController {
         return ResponseEntity.ok(leaderboardService.getLeaderboardPage(category, page, size, date));
     }
 
+    @GetMapping("/{category}/all")
+    public ResponseEntity<List<LeaderboardResponseDto>> getUsersByCategory(
+            @PathVariable String category,
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
+    ) {
+        return ResponseEntity.ok(leaderboardService.getAllLeaderboard(category, date));
+    }
+
     @Operation(
             summary = "유저의 점수 조회",
             description =
@@ -57,5 +68,10 @@ public class LeaderboardController {
             LocalDate date
     ) {
         return ResponseEntity.ok(leaderboardService.getUserScoreInfo(category, userId, date));
+    }
+
+    @GetMapping("/top-users")
+    public ResponseEntity<Map<String, List<LeaderboardResponseDto>>> getLeaderboards() {
+        return ResponseEntity.ok(leaderboardService.getLeaderboards());
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
@@ -10,4 +10,5 @@ public interface LeaderboardRepository {
     Set<ZSetOperations.TypedTuple<String>> findPageWithSize(String key, int page, int size);
     Long findRankByUserId(String key, String userId);
     Double findScoreByUserId(String key, String userId);
+    Set<ZSetOperations.TypedTuple<String>> findAll(String key);
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepositoryImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepositoryImpl.java
@@ -39,4 +39,10 @@ public class LeaderboardRepositoryImpl implements LeaderboardRepository {
         Double score = stringRedisTemplate.opsForZSet().score(key, userId);
         return score != null ? score : 0.0;
     }
+
+    @Override
+    public Set<ZSetOperations.TypedTuple<String>> findAll(String key) {
+        Set<ZSetOperations.TypedTuple<String>> result = stringRedisTemplate.opsForZSet().reverseRangeWithScores(key, 0, -1);
+        return result != null ? result : Collections.emptySet();
+    }
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
@@ -5,9 +5,12 @@ import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public interface LeaderboardService {
     void increaseScore(String category, String userId, double duration, LocalDateTime timestamp);
     List<LeaderboardResponseDto> getLeaderboardPage(String category, int page, int size, LocalDate date);
     LeaderboardResponseDto getUserScoreInfo(String category, String userId, LocalDate date);
+    List<LeaderboardResponseDto> getAllLeaderboard(String category, LocalDate date);
+    Map<String, List<LeaderboardResponseDto>> getLeaderboards();
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.leaderboard.service;
 
+import com.swmStrong.demo.domain.categoryPattern.facade.CategoryProvider;
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardRepository;
 import com.swmStrong.demo.domain.user.facade.UserInfoProvider;
@@ -9,10 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -20,12 +18,18 @@ public class LeaderboardServiceImpl implements LeaderboardService {
 
     private final LeaderboardRepository leaderboardRepository;
     private final UserInfoProvider userInfoProvider;
+    private final CategoryProvider categoryProvider;
 
     private static final String LEADERBOARD_KEY_PREFIX = "leaderboard:";
 
-    public LeaderboardServiceImpl(LeaderboardRepository leaderboardRepository, UserInfoProvider userInfoProvider) {
+    public LeaderboardServiceImpl(
+            LeaderboardRepository leaderboardRepository,
+            UserInfoProvider userInfoProvider,
+            CategoryProvider categoryProvider
+    ) {
         this.leaderboardRepository = leaderboardRepository;
         this.userInfoProvider = userInfoProvider;
+        this.categoryProvider = categoryProvider;
     }
 
     @Override
@@ -72,9 +76,50 @@ public class LeaderboardServiceImpl implements LeaderboardService {
 
         return LeaderboardResponseDto.builder()
                 .userId(userId)
+                .nickname(userInfoProvider.getNicknameByUserId(userId))
                 .score(leaderboardRepository.findScoreByUserId(key, userId))
                 .rank(leaderboardRepository.findRankByUserId(key, userId) + 1)
                 .build();
+    }
+
+    @Override
+    public List<LeaderboardResponseDto> getAllLeaderboard(String category, LocalDate date) {
+        if (date == null) {
+            date = LocalDate.now();
+        }
+
+        String key = generateKey(category, date);
+        Set<ZSetOperations.TypedTuple<String>> tuples = leaderboardRepository.findAll(key);
+
+        long rank = 1;
+        List<LeaderboardResponseDto> response = new ArrayList<>();
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            String userId = tuple.getValue();
+            double score = Optional.ofNullable(tuple.getScore()).orElse(0.0);
+            response.add(
+                    LeaderboardResponseDto.builder()
+                            .userId(userId)
+                            //TODO: 미리 닉네임을 레디스에 올려두기
+                            .nickname(userInfoProvider.getNicknameByUserId(userId))
+                            .score(score)
+                            .rank(rank++)
+                            .build()
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public Map<String, List<LeaderboardResponseDto>> getLeaderboards() {
+        Map<String, List<LeaderboardResponseDto>> response = new HashMap<>();
+
+        LocalDate date = LocalDate.now();
+        List<String> categories = categoryProvider.getCategories();
+
+        for (String category : categories) {
+            response.put(category, getLeaderboardPage(category, 1, 10, date));
+        }
+        return response;
     }
 
     private String generateKey(String category, LocalDate day) {

--- a/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
+++ b/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
@@ -114,6 +114,6 @@ public class PatternMatcher {
                 temp = temp.fail;
             }
         }
-        return matchedCategories.isEmpty()? Set.of("uncategorized"): matchedCategories;
+        return matchedCategories;
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/service/UsageLogServiceImpl.java
@@ -45,6 +45,10 @@ public class UsageLogServiceImpl implements UsageLogService {
         Set<String> categories = patternMatcher.search(saveUsageLogDto.title());
         categories.addAll(patternMatcher.search(saveUsageLogDto.app()));
 
+        if (categories.isEmpty()) {
+            categories.add("uncategorized");
+        }
+
         UsageLog usageLog = UsageLog.builder()
                 .userId(saveUsageLogDto.userId())
                 .app(saveUsageLogDto.app())


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [x] 코드 수정
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- leaderboard API 추가
- 상속관계 리팩토링
- 오류 수정 

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 리더보드 조회 관련한 클라이언트 요구사항을 충족했습니다.
- Set은 immutable하기 때문에 addAll 시 오류가 발생했고, HashSet으로 자료구조를 변경했습니다.

---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

약 10분 정도 예상합니다.
---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#27 리더보드 최초 로드 시 전체 조회