### PR TITLE
[SWM-82] categoryId 기반 조인 방식으로 변경

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/entity/CategoryPattern.java
@@ -2,6 +2,7 @@ package com.swmStrong.demo.domain.categoryPattern.entity;
 
 import jakarta.persistence.Id;
 import lombok.*;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.Set;
@@ -11,7 +12,7 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CategoryPattern {
     @Id
-    private String id;
+    private ObjectId id;
 
     private String category;
     private Set<String> patterns;
@@ -26,8 +27,7 @@ public class CategoryPattern {
     }
 
     @Builder
-    public CategoryPattern(String id, String category, Set<String> patterns, String color) {
-        this.id = id;
+    public CategoryPattern(String category, Set<String> patterns, String color) {
         this.category = category;
         this.patterns = patterns;
         this.color = color;

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProvider.java
@@ -1,7 +1,11 @@
 package com.swmStrong.demo.domain.categoryPattern.facade;
 
+import org.bson.types.ObjectId;
+
 import java.util.List;
 
 public interface CategoryProvider {
     List<String> getCategories();
+    String getCategoryById(ObjectId categoryId);
+    ObjectId getCategoryIdByCategory(String category);
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/facade/CategoryProviderImpl.java
@@ -2,6 +2,7 @@ package com.swmStrong.demo.domain.categoryPattern.facade;
 
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
 import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,5 +21,19 @@ public class CategoryProviderImpl implements CategoryProvider {
         return categoryPatternRepository.findAll().stream()
                 .map(CategoryPattern::getCategory)
                 .toList();
+    }
+
+    @Override
+    public String getCategoryById(ObjectId categoryId) {
+        return categoryPatternRepository.findById(categoryId)
+                .orElseThrow(IllegalArgumentException::new)
+                .getCategory();
+    }
+
+    @Override
+    public ObjectId getCategoryIdByCategory(String category) {
+        return categoryPatternRepository.findByCategory(category)
+                .orElseThrow(IllegalArgumentException::new)
+                .getId();
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/initializer/CategoryPatternInitializer.java
@@ -4,7 +4,6 @@ import com.swmStrong.demo.domain.categoryPattern.dto.CategoryPatternJSONDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.PatternRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
-import com.swmStrong.demo.domain.categoryPattern.repository.CustomCategoryPatternRepository;
 import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import com.swmStrong.demo.infra.json.JsonLoader;
 import org.springframework.beans.factory.SmartInitializingSingleton;
@@ -40,7 +39,6 @@ public class CategoryPatternInitializer implements SmartInitializingSingleton {
             if (!categoryPatternService.existsByCategory(entry.getCategory())) {
                 categoryPatternService.addCategory(CategoryRequestDto.of(entry.getCategory(), entry.getColor()));
             }
-
             Set<String> newPatterns = entry.getPatterns();
             newPatterns.removeAll(categoryPatternRepository.findPatternsByCategory(entry.getCategory()));
             for (String pattern: newPatterns) {

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/repository/CategoryPatternRepository.java
@@ -2,11 +2,12 @@ package com.swmStrong.demo.domain.categoryPattern.repository;
 
 
 import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface CategoryPatternRepository extends MongoRepository<CategoryPattern, String>, CustomCategoryPatternRepository {
+public interface CategoryPatternRepository extends MongoRepository<CategoryPattern, ObjectId>, CustomCategoryPatternRepository {
     boolean existsByCategory(String category);
     void deletePatternCategoryByCategory(String category);
     Optional<CategoryPattern> findByCategory(String category);

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -43,12 +43,11 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
     @Override
     public void addPattern(String category, PatternRequestDto patternRequestDto) {
-        if (!categoryPatternRepository.existsByCategory(category)) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리");
-        }
+        CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
+                        .orElseThrow(IllegalArgumentException::new);
 
         categoryPatternRepository.addPattern(category, patternRequestDto.pattern());
-        patternMatcher.insert(patternRequestDto.pattern(), category);
+        patternMatcher.insert(patternRequestDto.pattern(), categoryPattern.getId());
     }
 
     @Override
@@ -90,6 +89,7 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
     @Override
     public void updateCategory(String category, UpdateCategoryRequestDto updateCategoryRequestDto) {
+        //TODO: 중복 카테고리명에 대한 제한 만들기
         CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
                 .orElseThrow(IllegalArgumentException::new);
 

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/consumer/LeaderboardStreamConsumer.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/consumer/LeaderboardStreamConsumer.java
@@ -48,7 +48,7 @@ public class LeaderboardStreamConsumer extends AbstractRedisStreamConsumer {
                     LeaderBoardUsageMessage message = objectMapper.convertValue(valueMap, LeaderBoardUsageMessage.class);
 
                     leaderboardService.increaseScore(
-                            message.category(),
+                            message.categoryId(),
                             message.userId(),
                             message.duration(),
                             message.timestamp()

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface LeaderboardService {
-    void increaseScore(String category, String userId, double duration, LocalDateTime timestamp);
+    void increaseScore(String categoryId, String userId, double duration, LocalDateTime timestamp);
     List<LeaderboardResponseDto> getLeaderboardPage(String category, int page, int size, LocalDate date);
     LeaderboardResponseDto getUserScoreInfo(String category, String userId, LocalDate date);
     List<LeaderboardResponseDto> getAllLeaderboard(String category, LocalDate date);

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -5,6 +5,7 @@ import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardRepository;
 import com.swmStrong.demo.domain.user.facade.UserInfoProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
@@ -33,8 +34,11 @@ public class LeaderboardServiceImpl implements LeaderboardService {
     }
 
     @Override
-    public void increaseScore(String category, String userId, double duration, LocalDateTime timestamp) {
+    public void increaseScore(String categoryId, String userId, double duration, LocalDateTime timestamp) {
         LocalDate day = timestamp.toLocalDate();
+        ObjectId categoryObjectId = new ObjectId(categoryId);
+        String category = categoryProvider.getCategoryById(categoryObjectId);
+
         String key = generateKey(category, day);
         log.info("Increase score for user {} to {}", userId, duration);
         leaderboardRepository.increaseScoreByUserId(key, userId, duration);

--- a/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
+++ b/src/main/java/com/swmStrong/demo/domain/matcher/core/PatternMatcher.java
@@ -4,6 +4,7 @@ import com.swmStrong.demo.domain.categoryPattern.entity.CategoryPattern;
 import com.swmStrong.demo.domain.categoryPattern.repository.CategoryPatternRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -30,7 +31,7 @@ public class PatternMatcher {
                 continue;
             }
             for (String pattern: categoryPattern.getPatterns()) {
-                insert(pattern, categoryPattern.getCategory());
+                insert(pattern, categoryPattern.getId());
             }
         }
         connect();
@@ -41,7 +42,7 @@ public class PatternMatcher {
         char key;
         HashMap<Character, Node> children = new HashMap<>();
         Node fail = null;
-        Set<String> categories = new HashSet<>();
+        Set<ObjectId> categories = new HashSet<>();
 
         public Node(char key) {
             this.key = key;
@@ -53,14 +54,14 @@ public class PatternMatcher {
     }
 
 
-    public void insert(String pattern, String category) {
+    public void insert(String pattern, ObjectId categoryId) {
         Node now = this.root;
         pattern = pattern.toLowerCase();
         for (char c: pattern.toCharArray()) {
             now = now.children.computeIfAbsent(c, Node::new);
         }
-        now.categories.add(category);
-        log.info("insert pattern: {} category: {}", pattern, category);
+        now.categories.add(categoryId);
+        log.info("insert pattern: {} categoryId: {}", pattern, categoryId);
     }
 
     private void connect() {
@@ -92,10 +93,10 @@ public class PatternMatcher {
         }
     }
 
-    public Set<String> search(String title) {
+    public Set<ObjectId> search(String title) {
         Node now = this.root;
         title = title.toLowerCase();
-        Set<String> matchedCategories = new HashSet<>();
+        Set<ObjectId> matchedCategories = new HashSet<>();
         for (char c: title.toCharArray()) {
 
             while (now != null && now != this.root && !now.children.containsKey(c)) {

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/entity/UsageLog.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/entity/UsageLog.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -14,17 +15,17 @@ import java.util.Set;
 @Document(collection = "usage_logs")
 public class UsageLog {
     @Id
-    private String id;
+    private ObjectId id;
 
     private String userId;
     private LocalDateTime timestamp;
     private double duration;
     private String app;
     private String title;
-    private Set<String> categories;
+    private Set<ObjectId> categories;
 
     @Builder
-    public UsageLog(String userId, LocalDateTime timestamp, double duration, String app, String title, Set<String> categories) {
+    public UsageLog(String userId, LocalDateTime timestamp, double duration, String app, String title, Set<ObjectId> categories) {
         this.userId = userId;
         this.timestamp = timestamp;
         this.duration = duration;
@@ -33,7 +34,7 @@ public class UsageLog {
         this.categories = categories;
     }
 
-    public void addCategory(String category) {
+    public void addCategory(ObjectId category) {
         this.categories.add(category);
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/repository/UsageLogRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/repository/UsageLogRepository.java
@@ -2,22 +2,23 @@ package com.swmStrong.demo.domain.usageLog.repository;
 
 import com.swmStrong.demo.domain.usageLog.dto.CategoryUsageDto;
 import com.swmStrong.demo.domain.usageLog.entity.UsageLog;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface UsageLogRepository extends MongoRepository<UsageLog, String> {
+public interface UsageLogRepository extends MongoRepository<UsageLog, ObjectId> {
     List<UsageLog> findByUserId(String userId);
 
     @Aggregation(pipeline = {
             "{ $match: { userId: ?0, timestamp: { $gte: ?1, $lt: ?2 } } }",
             "{ $unwind: '$categories' }",
             "{ $group: { _id: '$categories', duration: { $sum: '$duration' } } }",
-            "{ $lookup: {from: 'category_pattern', localField: '_id', foreignField: 'category', as: 'patternDocs' } }",
+            "{ $lookup: {from: 'category_pattern', localField: '_id', foreignField: '_id', as: 'patternDocs' } }",
             "{ $unwind: { path: '$patternDocs', preserveNullAndEmptyArrays: true } }",
-            "{ $project: { category: '$_id', duration: 1, color: '$patternDocs.color' } }"
+            "{ $project: { category: '$patternDocs.category', duration: 1, color: '$patternDocs.color' } }"
     })
     List<CategoryUsageDto> findByUserIdAndTimestampBetween(
             String userId,

--- a/src/main/java/com/swmStrong/demo/message/dto/LeaderBoardUsageMessage.java
+++ b/src/main/java/com/swmStrong/demo/message/dto/LeaderBoardUsageMessage.java
@@ -1,14 +1,23 @@
 package com.swmStrong.demo.message.dto;
 
 import lombok.Builder;
+import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
 
-@Builder
 public record LeaderBoardUsageMessage(
         String userId,
-        String category,
+        String categoryId,
         double duration,
         LocalDateTime timestamp
 ) {
+    @Builder
+    public LeaderBoardUsageMessage(String userId, ObjectId categoryId, double duration, LocalDateTime timestamp) {
+        this(
+                userId,
+                categoryId != null ? categoryId.toHexString() : null,
+                duration,
+                timestamp
+        );
+    }
 }

--- a/src/main/resources/data/category-patterns.json
+++ b/src/main/resources/data/category-patterns.json
@@ -1,35 +1,38 @@
 {
   "categoryPatterns": [
     {
-      "category": "uncategorized",
-      "color": "#CCCCCC",
-      "patterns": []
-    },
-    {
-      "category": "develop",
-      "color": "#000000",
+      "category": "Development",
+      "color": "#6495ED",
       "patterns": [
-        "code",
+        "vscode",
         "intellij",
         "xcode",
         "goland",
         "postman",
         "mysqlworkbench",
         "mongodb compass",
-        ".swift",
-        ".py",
-        ".java",
+        "code",
         ".cpp",
-        ".c",
-        ".tsx",
+        ".java",
         ".ts",
+        ".tsx",
         ".js",
         ".jsx",
-        "chatgpt"
+        ".swift",
+        ".c",
+        ".py",
+        ".vue"
       ]
     },
     {
-      "category": "sns",
+      "category": "Uncategorized",
+      "color": "#CCCCCC",
+      "patterns": [
+
+      ]
+    },
+    {
+      "category": "SNS",
       "color": "#F39C12",
       "patterns": [
         "instagram",
@@ -37,11 +40,12 @@
         "threads",
         "facebook",
         "twitter",
-        "snapchat"
+        "snapchat",
+        "카카오톡"
       ]
     },
     {
-      "category": "youtube",
+      "category": "YouTube",
       "color": "#E74C3C",
       "patterns": [
         "youtube",
@@ -50,7 +54,7 @@
       ]
     },
     {
-      "category": "documentation",
+      "category": "Documentation",
       "color": "#3498DB",
       "patterns": [
         "notion",
@@ -61,7 +65,7 @@
       ]
     },
     {
-      "category": "design",
+      "category": "Design",
       "color": "#9B59B6",
       "patterns": [
         "figma",
@@ -72,14 +76,23 @@
       ]
     },
     {
-      "category": "communication",
+      "category": "Communication",
       "color": "#27AE60",
       "patterns": [
         "slack",
         "discord",
         "zoom",
         "teams",
-        "meet"
+        "meet",
+        "line"
+      ]
+    },
+    {
+      "category": "LLM",
+      "color": "#123456",
+      "patterns": [
+        "chatgpt",
+        "claude"
       ]
     }
   ]


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [ ] 신규 기능
- [x] 코드 수정
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

categoryId 기반 조인 방식으로 변경

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- category 문자열을 통해 조인하는 기존의 방식은 category의 이름이 바뀌었을 때 기존의 매핑이 끊어지는 오류가 있었습니다.
- 이를 categoryId 기반 매핑을 통해 해결했고, 과정에서 mongoDB가 기본적으로 PK에 ObjectId를 사용하고, String 과의 비교가 불가능함을 확인하고, PK타입을 변경해 해결했습니다.
---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

약 10분 - 15분 정도 예상됩니다.
---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#29 category를 수정했을 때 이전의 데이터와 매칭되지 않는 현상