### PR TITLE
[SWM-54, SWM-95] Api Response 통일, 비회원 토큰 문제 해결

### DIFF
--- a/src/main/java/com/swmStrong/demo/common/exception/ApiException.java
+++ b/src/main/java/com/swmStrong/demo/common/exception/ApiException.java
@@ -2,10 +2,13 @@ package com.swmStrong.demo.common.exception;
 
 import com.swmStrong.demo.common.exception.code.ErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ApiException extends RuntimeException {
     private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
@@ -10,27 +10,34 @@ public enum ErrorCode implements BaseCode {
     // --- 400 BAD REQUEST ---
     _BAD_REQUEST("4000", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
     _VALIDATION_ERROR("4001", "입력값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    USER_MISMATCH("4002", "토큰 생성 에러: 회원 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
 
+    // --- 401 UNAUTHORIZED ---
     _UNAUTHORIZED("4010", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     _INVALID_TOKEN("4011", "토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    _SECURITY("401Z", "시큐리티 관련 오류입니다.", HttpStatus.UNAUTHORIZED),
 
+    // --- 403 FORBIDDEN ---
     _FORBIDDEN("4030", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
+    // --- 404 NOT FOUND ---
     _NOT_FOUND("4040", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
-    _CONFLICT("4090", "이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
-
-    _INTERNAL_SERVER_ERROR("5000", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-
-
-    // 커스텀 에러
     USER_NOT_FOUND("4041", "존재하지 않는 유저입니다", HttpStatus.NOT_FOUND),
     SUBSCRIPTION_PLAN_NOT_FOUND("4042", "존재하지 않는 구독 플랜입니다", HttpStatus.NOT_FOUND),
+    CATEGORY_NOT_FOUND("4044", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),
+    PATTERN_NOT_FOUND("4045", "존재하지 않는 패턴입니다.", HttpStatus.NOT_FOUND),
+
+
+    // --- 409 CONFLICT ---
+    _CONFLICT("4090", "이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
     DUPLICATE_NICKNAME("4091", "이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
     DUPLICATE_USER_ID("4092", "이미 등록된 유저 아이디입니다.", HttpStatus.CONFLICT),
+    USER_ALREADY_REGISTERED("4093", "이미 가입된 회원입니다.", HttpStatus.CONFLICT),
+    DUPLICATE_CATEGORY("4094", "이미 존재하는 카테고리입니다.", HttpStatus.CONFLICT),
 
 
-    // 결제 관련 에러
+    // --- 500 INTERNAL SERVER ERROR ---
+    _INTERNAL_SERVER_ERROR("5000", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     PAYMENT_FAILED("5001", "결제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     PAYMENT_CANCELLATION_FAILED("5002", "결제 취소가 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/com/swmStrong/demo/common/response/CustomResponseEntity.java
+++ b/src/main/java/com/swmStrong/demo/common/response/CustomResponseEntity.java
@@ -1,0 +1,17 @@
+package com.swmStrong.demo.common.response;
+
+import com.swmStrong.demo.common.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+
+public class CustomResponseEntity {
+
+    public static <T> ResponseEntity<ApiResponse<T>> of(SuccessCode successCode, T data) {
+        return ResponseEntity
+                .status(successCode.getHttpStatus())
+                .body(ApiResponse.success(successCode, data));
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> of(SuccessCode successCode) {
+        return of(successCode, null);
+    }
+}

--- a/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationFailureHandler.java
@@ -28,9 +28,13 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("failMessage", exception.getMessage());
+
+        responseMap.put("isSuccess", false);
+        responseMap.put("code", "401A");
+        responseMap.put("message", exception.getMessage());
+        responseMap.put("data", null);
+
         objectMapper.writeValue(response.getOutputStream(), responseMap);
     }
 }

--- a/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -45,7 +45,7 @@ public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthent
 
 
         String userAgent = request.getHeader("User-Agent");
-        TokenResponseDto tokenResponseDto = tokenUtil.getToken(principal.getUserId(), userAgent, role);
+        TokenResponseDto tokenResponseDto = tokenUtil.getToken(principal.userId(), userAgent, role);
 
         response.setStatus(HttpServletResponse.SC_OK);
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/swmStrong/demo/config/security/principal/SecurityPrincipal.java
+++ b/src/main/java/com/swmStrong/demo/config/security/principal/SecurityPrincipal.java
@@ -8,22 +8,17 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
-@Getter
-@Builder
-public class SecurityPrincipal implements UserDetails {
-    private final String userId;
-    private final String email;
-    private final GrantedAuthority grantedAuthority;
 
-    public SecurityPrincipal(String userId, String email, GrantedAuthority grantedAuthority) {
-        this.userId = userId;
-        this.email = email;
-        this.grantedAuthority = grantedAuthority;
-    }
+@Builder
+public record SecurityPrincipal(
+        String userId,
+        String nickname,
+        GrantedAuthority grantedAuthority
+) implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
+        return nickname;
     }
 
     @Override

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -1,5 +1,8 @@
 package com.swmStrong.demo.domain.categoryPattern.controller;
 
+import com.swmStrong.demo.common.exception.code.SuccessCode;
+import com.swmStrong.demo.common.response.ApiResponse;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryRequestDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.CategoryResponseDto;
 import com.swmStrong.demo.domain.categoryPattern.dto.UpdateCategoryRequestDto;
@@ -33,9 +36,9 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping("/{category}")
-    public ResponseEntity<Void> addPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> addPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
         categoryPatternService.addPattern(category, patternRequestDto);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 
     @Operation(
@@ -45,9 +48,9 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{category}/pattern")
-    public ResponseEntity<Void> deletePatternByCategoryAndPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> deletePatternByCategoryAndPattern(@PathVariable String category, @RequestBody PatternRequestDto patternRequestDto) {
         categoryPatternService.deletePatternByCategory(category, patternRequestDto);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._NO_CONTENT);
     }
 
     @Operation(
@@ -59,9 +62,9 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{category}")
-    public ResponseEntity<Void> deletePatternByCategory(@PathVariable String category) {
+    public ResponseEntity<ApiResponse<Void>> deletePatternByCategory(@PathVariable String category) {
         categoryPatternService.deleteCategory(category);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._NO_CONTENT);
     }
 
     @Operation(
@@ -71,8 +74,11 @@ public class CategoryPatternController {
                 "<p> 카테고리 내부의 패턴도 함께 출력된다. </p>"
     )
     @GetMapping("/{category}")
-    public ResponseEntity<CategoryResponseDto> getCategoryPatternByCategory(@PathVariable String category) {
-        return ResponseEntity.ok(categoryPatternService.getCategoryPatternByCategory(category));
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> getCategoryPatternByCategory(@PathVariable String category) {
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                categoryPatternService.getCategoryPatternByCategory(category)
+        );
     }
 
     @Operation(
@@ -82,8 +88,11 @@ public class CategoryPatternController {
                 "<p> 카테고리 내부의 패턴도 함께 출력된다. </p>"
     )
     @GetMapping
-    public ResponseEntity<List<CategoryResponseDto>> getAllCategories() {
-        return ResponseEntity.ok(categoryPatternService.getCategories());
+    public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getAllCategories() {
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                categoryPatternService.getCategories()
+        );
     }
 
     @Operation(
@@ -96,9 +105,12 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @PatchMapping("/{category}")
-    public ResponseEntity<Void> updateCategory(@PathVariable String category, @RequestBody UpdateCategoryRequestDto updateCategoryRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> updateCategory(
+            @PathVariable String category,
+            @RequestBody UpdateCategoryRequestDto updateCategoryRequestDto
+    ) {
         categoryPatternService.updateCategory(category, updateCategoryRequestDto);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 
     @Operation(
@@ -109,8 +121,8 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
-    public ResponseEntity<Void> addCategory(@RequestBody CategoryRequestDto categoryRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> addCategory(@RequestBody CategoryRequestDto categoryRequestDto) {
         categoryPatternService.addCategory(categoryRequestDto);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/controller/LeaderboardController.java
@@ -1,5 +1,8 @@
 package com.swmStrong.demo.domain.leaderboard.controller;
 
+import com.swmStrong.demo.common.exception.code.SuccessCode;
+import com.swmStrong.demo.common.response.ApiResponse;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import com.swmStrong.demo.domain.leaderboard.service.LeaderboardService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +33,7 @@ public class LeaderboardController {
                 "<p> 날짜를 입력하지 않는 경우, 오늘을 기준으로 한다. </p>"
     )
     @GetMapping("/{category}/daily")
-    public ResponseEntity<List<LeaderboardResponseDto>> getTopUsersByCategoryDaily(
+    public ResponseEntity<ApiResponse<List<LeaderboardResponseDto>>> getTopUsersByCategoryDaily(
             @PathVariable String category,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -38,7 +41,10 @@ public class LeaderboardController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
             ) {
-        return ResponseEntity.ok(leaderboardService.getLeaderboardPageDaily(category, page, size, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getLeaderboardPageDaily(category, page, size, date)
+        );
     }
 
     @Operation(
@@ -48,8 +54,8 @@ public class LeaderboardController {
                 "<p> page 의 기본값은 1이다. </p>" +
                 "<p> 날짜를 입력하지 않는 경우, 오늘을 기준으로 한다. </p>"
     )
-    @GetMapping("/{category}/weely")
-    public ResponseEntity<List<LeaderboardResponseDto>> getTopUsersByCategoryWeely(
+    @GetMapping("/{category}/weekly")
+    public ResponseEntity<ApiResponse<List<LeaderboardResponseDto>>> getTopUsersByCategoryWeekly(
             @PathVariable String category,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -57,7 +63,10 @@ public class LeaderboardController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
     ) {
-        return ResponseEntity.ok(leaderboardService.getLeaderboardPageWeekly(category, page, size, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getLeaderboardPageWeekly(category, page, size, date)
+        );
     }
 
     @Operation(
@@ -68,7 +77,7 @@ public class LeaderboardController {
                 "<p> 날짜를 입력하지 않는 경우, 오늘을 기준으로 한다. </p>"
     )
     @GetMapping("/{category}/monthly")
-    public ResponseEntity<List<LeaderboardResponseDto>> getTopUsersByCategoryMonthly(
+    public ResponseEntity<ApiResponse<List<LeaderboardResponseDto>>> getTopUsersByCategoryMonthly(
             @PathVariable String category,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -76,7 +85,10 @@ public class LeaderboardController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
     ) {
-        return ResponseEntity.ok(leaderboardService.getLeaderboardPageMonthly(category, page, size, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getLeaderboardPageMonthly(category, page, size, date)
+        );
     }
 
     @Operation(
@@ -86,13 +98,16 @@ public class LeaderboardController {
                 "<p> 페이징 없는 버전이다. </p>"
     )
     @GetMapping("/{category}/all")
-    public ResponseEntity<List<LeaderboardResponseDto>> getUsersByCategory(
+    public ResponseEntity<ApiResponse<List<LeaderboardResponseDto>>> getUsersByCategory(
             @PathVariable String category,
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
     ) {
-        return ResponseEntity.ok(leaderboardService.getAllLeaderboard(category, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getAllLeaderboard(category, date)
+        );
     }
 
     @Operation(
@@ -104,14 +119,17 @@ public class LeaderboardController {
 
     )
     @GetMapping("/{category}/user-info")
-    public ResponseEntity<LeaderboardResponseDto> getUserInfo(
+    public ResponseEntity<ApiResponse<LeaderboardResponseDto>> getUserInfo(
             @PathVariable String category,
             @RequestParam String userId,
             @RequestParam(required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
     ) {
-        return ResponseEntity.ok(leaderboardService.getUserScoreInfo(category, userId, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getUserScoreInfo(category, userId, date)
+        );
     }
 
     @Operation(
@@ -121,7 +139,10 @@ public class LeaderboardController {
                 "<p> 일단 당일만 조회 가능하다. </p>"
     )
     @GetMapping("/top-users")
-    public ResponseEntity<Map<String, List<LeaderboardResponseDto>>> getLeaderboards() {
-        return ResponseEntity.ok(leaderboardService.getLeaderboards());
+    public ResponseEntity<ApiResponse<Map<String, List<LeaderboardResponseDto>>>> getLeaderboards() {
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                leaderboardService.getLeaderboards()
+        );
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
@@ -1,5 +1,8 @@
 package com.swmStrong.demo.domain.loginCredential.controller;
 
+import com.swmStrong.demo.common.exception.code.SuccessCode;
+import com.swmStrong.demo.common.response.ApiResponse;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.loginCredential.dto.LoginRequestDto;
 import com.swmStrong.demo.domain.loginCredential.dto.UpgradeRequestDto;
@@ -31,9 +34,9 @@ public class LoginCredentialController {
                 "<p> 당장은 바로 회원 가입하는 기능이 없다. (추가 예정) </p>"
     )
     @PostMapping("/register")
-    public ResponseEntity<Void> upgradeToMember(@RequestBody UpgradeRequestDto upgradeRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> upgradeToMember(@RequestBody UpgradeRequestDto upgradeRequestDto) {
         loginCredentialService.upgradeToUser(upgradeRequestDto);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 
     @Operation(
@@ -43,12 +46,15 @@ public class LoginCredentialController {
                 "<p> User-Agent가 다르면 리프레시가 안된다. </p>"
     )
     @PostMapping("/refresh")
-    public ResponseEntity<TokenResponseDto> tokenRefresh(
+    public ResponseEntity<ApiResponse<TokenResponseDto>> tokenRefresh(
             HttpServletRequest request,
             @RequestBody RefreshTokenRequestDto refreshTokenRequestDto,
             @AuthenticationPrincipal SecurityPrincipal securityPrincipal
     ) {
-        return ResponseEntity.ok(loginCredentialService.tokenRefresh(securityPrincipal.getUserId(), request, refreshTokenRequestDto));
+        return CustomResponseEntity.of(
+                SuccessCode._CREATED,
+                loginCredentialService.tokenRefresh(securityPrincipal.getUserId(), request, refreshTokenRequestDto)
+        );
     }
 
     @Operation(
@@ -58,8 +64,11 @@ public class LoginCredentialController {
                 "<p> 해당 기능은 spring security로 선언해 service 레이어에서 찾을 수 없다. </p>"
     )
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<TokenResponseDto>> login(@RequestBody LoginRequestDto loginRequestDto) {
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                new TokenResponseDto(null, null)
+        );
     }
 
     @Operation(
@@ -69,8 +78,8 @@ public class LoginCredentialController {
                 "<p> 해당 기능은 spring security로 선언해 service 레이어에서 찾을 수 없다. </p>"
     )
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 }
 

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
@@ -53,7 +53,7 @@ public class LoginCredentialController {
     ) {
         return CustomResponseEntity.of(
                 SuccessCode._CREATED,
-                loginCredentialService.tokenRefresh(securityPrincipal.getUserId(), request, refreshTokenRequestDto)
+                loginCredentialService.tokenRefresh(securityPrincipal.userId(), request, refreshTokenRequestDto)
         );
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProvider.java
@@ -4,7 +4,6 @@ import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.global.Role;
 
 public interface LoginCredentialProvider {
-    SecurityPrincipal loadPrincipalByUserId(String userId);
     SecurityPrincipal loadPrincipalByEmail(String email);
     boolean isPasswordMatched(String email, String password);
     Role loadRoleByUserId(String userId);

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
@@ -21,6 +21,7 @@ public class LoginCredentialProviderImpl implements LoginCredentialProvider {
     }
 
     @Override
+    //TODO: loginCredential을 기반으로 조회하면 비회원은 조회당하지 못합니다.
     public SecurityPrincipal loadPrincipalByUserId(String userId) {
         LoginCredential loginCredential = loginCredentialRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
@@ -35,7 +35,7 @@ public class LoginCredentialProviderImpl implements LoginCredentialProvider {
     @Override
     public SecurityPrincipal loadPrincipalByEmail(String email) {
         LoginCredential loginCredential = loginCredentialRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 이메일 입니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("등록되지 않은 이메일 입니다."));
 
         return SecurityPrincipal.builder()
                 .userId(loginCredential.getId())
@@ -47,7 +47,7 @@ public class LoginCredentialProviderImpl implements LoginCredentialProvider {
     @Override
     public boolean isPasswordMatched(String email, String password) {
         LoginCredential loginCredential = loginCredentialRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("등록되지 않는 이메일입니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("등록되지 않은 이메일입니다."));
 
         return passwordEncoder.matches(password, loginCredential.getPassword());
     }

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
@@ -21,26 +21,13 @@ public class LoginCredentialProviderImpl implements LoginCredentialProvider {
     }
 
     @Override
-    //TODO: loginCredential을 기반으로 조회하면 비회원은 조회당하지 못합니다.
-    public SecurityPrincipal loadPrincipalByUserId(String userId) {
-        LoginCredential loginCredential = loginCredentialRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
-
-        return SecurityPrincipal.builder()
-                .userId(loginCredential.getId())
-                .email(loginCredential.getEmail())
-                .grantedAuthority(new SimpleGrantedAuthority(loginCredential.getRole().getAuthority()))
-                .build();
-    }
-
-    @Override
     public SecurityPrincipal loadPrincipalByEmail(String email) {
         LoginCredential loginCredential = loginCredentialRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("등록되지 않은 이메일 입니다."));
 
         return SecurityPrincipal.builder()
                 .userId(loginCredential.getId())
-                .email(loginCredential.getEmail())
+                .nickname(loginCredential.getNickname())
                 .grantedAuthority(new SimpleGrantedAuthority(loginCredential.getRole().getAuthority()))
                 .build();
     }

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/service/LoginCredentialServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/service/LoginCredentialServiceImpl.java
@@ -1,5 +1,7 @@
 package com.swmStrong.demo.domain.loginCredential.service;
 
+import com.swmStrong.demo.common.exception.ApiException;
+import com.swmStrong.demo.common.exception.code.ErrorCode;
 import com.swmStrong.demo.domain.loginCredential.dto.UpgradeRequestDto;
 import com.swmStrong.demo.domain.loginCredential.entity.LoginCredential;
 import com.swmStrong.demo.domain.loginCredential.repository.LoginCredentialRepository;
@@ -38,7 +40,7 @@ public class LoginCredentialServiceImpl implements LoginCredentialService {
         User user = userUpdateProvider.getUserByUserId(upgradeRequestDto.userId());
 
         if (user instanceof LoginCredential) {
-            throw new IllegalArgumentException("가입된 회원");
+            throw new ApiException(ErrorCode.USER_ALREADY_REGISTERED);
         }
 
         loginCredentialRepository.insertLoginCredential(

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
@@ -42,7 +42,7 @@ public class UsageLogController {
             @AuthenticationPrincipal SecurityPrincipal securityPrincipal,
             @RequestBody List<SaveUsageLogDto> usageLogDtoList
     ) {
-        usageLogService.saveAll(securityPrincipal.getUserId(), usageLogDtoList);
+        usageLogService.saveAll(securityPrincipal.userId(), usageLogDtoList);
         return CustomResponseEntity.of(SuccessCode._OK);
     }
 
@@ -59,7 +59,7 @@ public class UsageLogController {
     ) {
         return CustomResponseEntity.of(
                 SuccessCode._OK,
-                usageLogService.getUsageLogByUserId(securityPrincipal.getUserId())
+                usageLogService.getUsageLogByUserId(securityPrincipal.userId())
         );
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
+++ b/src/main/java/com/swmStrong/demo/domain/usageLog/controller/UsageLogController.java
@@ -1,5 +1,8 @@
 package com.swmStrong.demo.domain.usageLog.controller;
 
+import com.swmStrong.demo.common.exception.code.SuccessCode;
+import com.swmStrong.demo.common.response.ApiResponse;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.usageLog.dto.CategoryUsageDto;
 import com.swmStrong.demo.domain.usageLog.dto.SaveUsageLogDto;
@@ -35,12 +38,12 @@ public class UsageLogController {
                 "<p> 배열 안에 json이 있는 형태로 보내면 된다.</p>"
     )
     @PostMapping
-    public ResponseEntity<Void> saveUsageLog(
+    public ResponseEntity<ApiResponse<Void>> saveUsageLog(
             @AuthenticationPrincipal SecurityPrincipal securityPrincipal,
             @RequestBody List<SaveUsageLogDto> usageLogDtoList
     ) {
         usageLogService.saveAll(securityPrincipal.getUserId(), usageLogDtoList);
-        return ResponseEntity.ok().build();
+        return CustomResponseEntity.of(SuccessCode._OK);
     }
 
     @Operation(
@@ -51,10 +54,13 @@ public class UsageLogController {
                 "<p> 정리되지 않은 로우 데이터를 반환한다. </p>"
     )
     @GetMapping("/all")
-    public ResponseEntity<List<UsageLogResponseDto>> getUsageLogById(
+    public ResponseEntity<ApiResponse<List<UsageLogResponseDto>>> getUsageLogById(
             @AuthenticationPrincipal SecurityPrincipal securityPrincipal
     ) {
-        return ResponseEntity.ok(usageLogService.getUsageLogByUserId(securityPrincipal.getUserId()));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                usageLogService.getUsageLogByUserId(securityPrincipal.getUserId())
+        );
     }
 
 
@@ -67,13 +73,16 @@ public class UsageLogController {
                 "<p> 날짜를 입력하지 않으면 당일 날짜로 들어간다. </p>"
     )
     @GetMapping
-    public ResponseEntity<List<CategoryUsageDto>> getUsageLogByIdToday(
+    public ResponseEntity<ApiResponse<List<CategoryUsageDto>>> getUsageLogByIdToday(
             @RequestParam
             String userId,
             @RequestParam(required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date
     ) {
-        return ResponseEntity.ok(usageLogService.getUsageLogByUserIdAndDate(userId, date));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                usageLogService.getUsageLogByUserIdAndDate(userId, date)
+        );
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.swmStrong.demo.domain.user.controller;
 
 import com.swmStrong.demo.common.response.ApiResponse;
 import com.swmStrong.demo.common.exception.code.SuccessCode;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.domain.user.dto.UnregisteredRequestDto;
 import com.swmStrong.demo.domain.user.dto.UserRequestDto;
 import com.swmStrong.demo.domain.user.dto.UserResponseDto;
@@ -27,11 +28,12 @@ public class UserController {
             description =
                     "<p> 새로운 유저를 생성한다.</p>"
     )
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<ApiResponse<UserResponseDto>> createGuestUser(@RequestBody UserRequestDto userRequestDto) {
-        return ResponseEntity
-                .status(SuccessCode._CREATED.getHttpStatus())
-                .body(ApiResponse.success(SuccessCode._CREATED, userService.registerGuestNickname(userRequestDto)));
+        return CustomResponseEntity.of(
+                SuccessCode._CREATED,
+                userService.registerGuestNickname(userRequestDto)
+        );
     }
 
     @Operation(
@@ -41,10 +43,10 @@ public class UserController {
     )
     @GetMapping("/is-nickname-duplicated")
     public ResponseEntity<ApiResponse<Boolean>> isGuestNicknameRegistered(@RequestParam(required = true) String nickname) {
-        Boolean result = userService.isGuestNicknameDuplicated(nickname);
-        return ResponseEntity
-                .status(SuccessCode._OK.getHttpStatus())
-                .body(ApiResponse.success(SuccessCode._OK, result));
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                userService.isGuestNicknameDuplicated(nickname)
+        );
     }
 
     @Operation(
@@ -55,7 +57,10 @@ public class UserController {
                 "<p> 등록일시같은 추가적인 유저 구분 수단을 반드시 보관하고 있고, 토큰 발급 시 넣어야 한다.</p>"
     )
     @PostMapping("/get-token")
-    public ResponseEntity<TokenResponseDto> getToken(HttpServletRequest request, @RequestBody UnregisteredRequestDto unregisteredRequestDto) {
-        return ResponseEntity.ok(userService.getToken(request, unregisteredRequestDto));
+    public ResponseEntity<ApiResponse<TokenResponseDto>> getToken(HttpServletRequest request, @RequestBody UnregisteredRequestDto unregisteredRequestDto) {
+        return CustomResponseEntity.of(
+                SuccessCode._CREATED,
+                userService.getToken(request, unregisteredRequestDto)
+        );
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserDetailsProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserDetailsProvider.java
@@ -1,0 +1,7 @@
+package com.swmStrong.demo.domain.user.facade;
+
+import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
+
+public interface UserDetailsProvider {
+    SecurityPrincipal loadPrincipalByUserId(String userId);
+}

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserDetailsProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserDetailsProviderImpl.java
@@ -1,0 +1,30 @@
+package com.swmStrong.demo.domain.user.facade;
+
+import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
+import com.swmStrong.demo.domain.user.entity.User;
+import com.swmStrong.demo.domain.user.repository.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsProviderImpl implements UserDetailsProvider {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsProviderImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public SecurityPrincipal loadPrincipalByUserId(String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+
+        return SecurityPrincipal.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .grantedAuthority(new SimpleGrantedAuthority(user.getRole().getAuthority()))
+                .build();
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
@@ -1,7 +1,5 @@
 package com.swmStrong.demo.domain.user.facade;
 
-import com.swmStrong.demo.domain.user.entity.User;
-
 public interface UserInfoProvider {
     String getNicknameByUserId(String userId);
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserUpdateProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserUpdateProviderImpl.java
@@ -1,5 +1,7 @@
 package com.swmStrong.demo.domain.user.facade;
 
+import com.swmStrong.demo.common.exception.ApiException;
+import com.swmStrong.demo.common.exception.code.ErrorCode;
 import com.swmStrong.demo.domain.global.Role;
 import com.swmStrong.demo.domain.user.entity.User;
 import com.swmStrong.demo.domain.user.repository.UserRepository;
@@ -23,6 +25,6 @@ public class UserUpdateProviderImpl implements UserUpdateProvider {
     @Override
     public User getUserByUserId(String userId) {
         return userRepository.findById(userId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
@@ -47,12 +47,12 @@ public class UserServiceImpl implements UserService {
     @Override
     public TokenResponseDto getToken(HttpServletRequest request, UnregisteredRequestDto unregisteredRequestDto) {
         User user = userRepository.findById(unregisteredRequestDto.userId())
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
         if (!user.getCreatedAt().truncatedTo(ChronoUnit.MILLIS)
                 .equals(unregisteredRequestDto.createdAt().truncatedTo(ChronoUnit.MILLIS))
         ) {
-            throw new IllegalArgumentException("비정상적인 요청 입니다..");
+            throw new ApiException(ErrorCode.USER_MISMATCH);
         }
 
         return tokenUtil.getToken(unregisteredRequestDto.userId(),  request.getHeader("User-Agent"), Role.UNREGISTERED);

--- a/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
@@ -3,6 +3,7 @@ package com.swmStrong.demo.util.token;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.global.Role;
 import com.swmStrong.demo.domain.loginCredential.facade.LoginCredentialProvider;
+import com.swmStrong.demo.domain.user.facade.UserDetailsProvider;
 import com.swmStrong.demo.util.redis.RedisUtil;
 import com.swmStrong.demo.util.token.dto.RefreshTokenRequestDto;
 import com.swmStrong.demo.util.token.dto.TokenResponseDto;
@@ -28,10 +29,12 @@ import static com.swmStrong.demo.util.redis.RedisUtil.REDIS_REFRESH_TOKEN_PREFIX
 public class TokenUtil {
     private final RedisUtil redisUtil;
     private final LoginCredentialProvider loginCredentialProvider;
+    private final UserDetailsProvider userDetailsProvider;
 
-    public TokenUtil(RedisUtil redisUtil, LoginCredentialProvider loginCredentialProvider) {
+    public TokenUtil(RedisUtil redisUtil, LoginCredentialProvider loginCredentialProvider, UserDetailsProvider userDetailsProvider) {
         this.redisUtil = redisUtil;
         this.loginCredentialProvider = loginCredentialProvider;
+        this.userDetailsProvider = userDetailsProvider;
     }
 
     @Value("${spring.jwt.salt}")
@@ -161,7 +164,7 @@ public class TokenUtil {
 
         String userId = claims.getSubject();
         String role = claims.get("role", String.class);
-        SecurityPrincipal principal = loginCredentialProvider.loadPrincipalByUserId(userId);
+        SecurityPrincipal principal = userDetailsProvider.loadPrincipalByUserId(userId);
         if (userId != null && role != null) {
             List<GrantedAuthority> authority = List.of(new SimpleGrantedAuthority(role));
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal, null, authority);


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [ ] 신규 기능
- [x] 코드 수정
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [x] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- api response,code 통일
- 비회원 토큰 기능 문제 해결

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 기존에 통일하지 않고 작업했던 부분을 모두 통일했습니다.
- SuccessCode를 중복으로 부르는 작업을 정적 팩토리 메서드 패턴으로 간소화 했습니다.
- loginCredential에 종속된 토큰 검사 책임을 user 단계로 내렸습니다.

---

## ⏰ 리뷰 시간 예상

약 10분 정도 예상됩니다.


---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지

---

## 🔗 관련 이슈
#3 api response, code 통일
#43 비회원 토큰 인증이 안되는 문제 