### PR TITLE
[SWM-98] 리더보드 쿼리 리팩토링 및 카테고리 관련 검증

### DIFF
--- a/src/main/java/com/swmStrong/demo/common/annotation/HexColor.java
+++ b/src/main/java/com/swmStrong/demo/common/annotation/HexColor.java
@@ -1,0 +1,21 @@
+package com.swmStrong.demo.common.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Pattern(
+        regexp = "^#([A-F0-9]{6})$",
+        message = "색상값은 #000000 - #FFFFFF 형식이어야 합니다."
+)
+public @interface HexColor {
+    String message() default "색상값은 #000000 - #FFFFFF 형식이어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/swmStrong/demo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swmStrong/demo/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,14 @@
 package com.swmStrong.demo.common.exception;
 import com.swmStrong.demo.common.response.ApiResponse;
 import com.swmStrong.demo.common.exception.code.ErrorCode;
+import com.swmStrong.demo.common.response.CustomResponseEntity;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.Optional;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -13,5 +18,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(code.getHttpStatus())
                 .body(ApiResponse.fail(code));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = ErrorCode._VALIDATION_ERROR;
+
+        String message = Optional.ofNullable(e.getBindingResult().getFieldError())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(errorCode.getMessage());
+
+        return CustomResponseEntity.of(errorCode, message);
     }
 }

--- a/src/main/java/com/swmStrong/demo/common/response/ApiResponse.java
+++ b/src/main/java/com/swmStrong/demo/common/response/ApiResponse.java
@@ -16,4 +16,8 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
         return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
     }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(false, errorCode.getCode(), message, null);
+    }
 }

--- a/src/main/java/com/swmStrong/demo/common/response/CustomResponseEntity.java
+++ b/src/main/java/com/swmStrong/demo/common/response/CustomResponseEntity.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.common.response;
 
+import com.swmStrong.demo.common.exception.code.ErrorCode;
 import com.swmStrong.demo.common.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
 
@@ -13,5 +14,17 @@ public class CustomResponseEntity {
 
     public static ResponseEntity<ApiResponse<Void>> of(SuccessCode successCode) {
         return of(successCode, null);
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> of(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> of(ErrorCode errorCode, String message) {
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.fail(errorCode, message));
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/controller/CategoryPatternController.java
@@ -11,6 +11,7 @@ import com.swmStrong.demo.domain.categoryPattern.service.CategoryPatternService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -107,7 +108,7 @@ public class CategoryPatternController {
     @PatchMapping("/{category}")
     public ResponseEntity<ApiResponse<Void>> updateCategory(
             @PathVariable String category,
-            @RequestBody UpdateCategoryRequestDto updateCategoryRequestDto
+            @RequestBody @Valid UpdateCategoryRequestDto updateCategoryRequestDto
     ) {
         categoryPatternService.updateCategory(category, updateCategoryRequestDto);
         return CustomResponseEntity.of(SuccessCode._OK);
@@ -121,7 +122,7 @@ public class CategoryPatternController {
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> addCategory(@RequestBody CategoryRequestDto categoryRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> addCategory(@RequestBody @Valid CategoryRequestDto categoryRequestDto) {
         categoryPatternService.addCategory(categoryRequestDto);
         return CustomResponseEntity.of(SuccessCode._OK);
     }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/CategoryRequestDto.java
@@ -1,8 +1,11 @@
 package com.swmStrong.demo.domain.categoryPattern.dto;
 
+import com.swmStrong.demo.common.annotation.HexColor;
+
 public record CategoryRequestDto(
         String category,
         Integer priority,
+        @HexColor
         String color
 ) {
     public static CategoryRequestDto of(String category, Integer priority, String color) {

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/dto/UpdateCategoryRequestDto.java
@@ -1,7 +1,10 @@
 package com.swmStrong.demo.domain.categoryPattern.dto;
 
+import com.swmStrong.demo.common.annotation.HexColor;
+
 public record UpdateCategoryRequestDto(
         String category,
+        @HexColor
         String color
 ) {
 }

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -33,8 +33,6 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
             throw new ApiException(ErrorCode.DUPLICATE_CATEGORY);
         }
 
-        //TODO: 색깔에 대한 정규표현식 만들어두기 (#000000 - #FFFFFF)
-
         CategoryPattern categoryPattern = CategoryPattern.builder()
                 .category(categoryRequestDto.category())
                 .color(categoryRequestDto.color())

--- a/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/categoryPattern/service/CategoryPatternServiceImpl.java
@@ -95,14 +95,19 @@ public class CategoryPatternServiceImpl implements CategoryPatternService {
 
     @Override
     public void updateCategory(String category, UpdateCategoryRequestDto updateCategoryRequestDto) {
-        //TODO: 중복 카테고리명에 대한 제한 만들기
+
         CategoryPattern categoryPattern = categoryPatternRepository.findByCategory(category)
                 .orElseThrow(() -> new ApiException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        if (categoryPatternRepository.existsByCategory(updateCategoryRequestDto.category())) {
+            throw new ApiException(ErrorCode.DUPLICATE_CATEGORY);
+        }
 
         if (updateCategoryRequestDto.category() != null) {
             categoryPattern.setCategory(updateCategoryRequestDto.category());
             patternMatcher.init();
         }
+
         if (updateCategoryRequestDto.color() != null) {
             categoryPattern.setColor(updateCategoryRequestDto.color());
         }

--- a/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/controller/UserController.java
@@ -53,7 +53,6 @@ public class UserController {
             summary = "비회원용 토큰 발급",
             description =
                 "<p> 비회원용 토큰 발급 수단이다. </p>" +
-                "<p> TODO: 추가적인 수단이 반드시 필요하다.</p>" +
                 "<p> 등록일시같은 추가적인 유저 구분 수단을 반드시 보관하고 있고, 토큰 발급 시 넣어야 한다.</p>"
     )
     @PostMapping("/get-token")

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProvider.java
@@ -1,5 +1,9 @@
 package com.swmStrong.demo.domain.user.facade;
 
+import java.util.List;
+import java.util.Map;
+
 public interface UserInfoProvider {
-    String getNicknameByUserId(String userId);
+    String loadNicknameByUserId(String userId);
+    Map<String, String> loadNicknamesByUserIds(List<String> userIds);
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserInfoProviderImpl.java
@@ -4,6 +4,10 @@ import com.swmStrong.demo.domain.user.entity.User;
 import com.swmStrong.demo.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 public class UserInfoProviderImpl implements UserInfoProvider {
 
@@ -14,9 +18,19 @@ public class UserInfoProviderImpl implements UserInfoProvider {
     }
 
     @Override
-    public String getNicknameByUserId(String userId) {
+    public String loadNicknameByUserId(String userId) {
         return userRepository.findById(userId)
                 .map(User::getNickname)
                 .orElse("Unknown");
+    }
+
+    @Override
+    public Map<String, String> loadNicknamesByUserIds(List<String> userIds) {
+        List<User> users = userRepository.findAllById(userIds);
+        Map<String, String> nicknames = new HashMap<>();
+        for (User user : users) {
+            nicknames.put(user.getNickname(), user.getNickname());
+        }
+        return nicknames;
     }
 }


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [ ] 신규 기능
- [x] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- 카테고리 검증 관련 로직 추가
- 리더보드 쿼리 리팩토링

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 카테고리 검증과 관련하여 color 코드를 검증할 수 있는 어노테이션을 만들었습니다.
- 카테고리 수정 시 중복된 카테고리가 생기지 않도록 예외처리를 추가했습니다.
- 리더보드 쿼리가 인원 수 만큼 N개 발생하던 것에서 N명의 닉네임을 한번의 쿼리로 검색할 수 있도록 수정했습니다.

---

## ⏰ 리뷰 시간 예상

- 약 10분 정도 예상됩니다.

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#48 카테고리 관련 검증 작업 