### PR TITLE
[SWM-72, SWM-100] 리더보드 히스토리 저장 및 소셜 로그인

### DIFF
--- a/src/main/java/com/swmStrong/demo/DemoApplication.java
+++ b/src/main/java/com/swmStrong/demo/DemoApplication.java
@@ -2,7 +2,9 @@ package com.swmStrong.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode implements BaseCode {
     _UNAUTHORIZED("4010", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     _INVALID_TOKEN("4011", "토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
     _SECURITY("401Z", "시큐리티 관련 오류입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_AUTHORIZATION_FAILED("4013", "토큰이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     // --- 403 FORBIDDEN ---
     _FORBIDDEN("4030", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/swmStrong/demo/common/exception/code/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode implements BaseCode {
     _BAD_REQUEST("4000", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
     _VALIDATION_ERROR("4001", "입력값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     USER_MISMATCH("4002", "토큰 생성 에러: 회원 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    PERIOD_KEY_ERROR("4003", "해당 기간 키값은 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // --- 401 UNAUTHORIZED ---
     _UNAUTHORIZED("4010", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/swmStrong/demo/config/security/WhiteListConfig.java
+++ b/src/main/java/com/swmStrong/demo/config/security/WhiteListConfig.java
@@ -18,6 +18,7 @@ public class WhiteListConfig {
 
     public static final String[] WHITE_LIST_FOR_GET = {
             PREFIX+"/category",
-            PREFIX+"/category/**"
+            PREFIX+"/category/**",
+            PREFIX+"/usage-log",
     };
 }

--- a/src/main/java/com/swmStrong/demo/config/security/WhiteListConfig.java
+++ b/src/main/java/com/swmStrong/demo/config/security/WhiteListConfig.java
@@ -6,6 +6,7 @@ public class WhiteListConfig {
     public static final String[] WHITE_LIST = {
             PREFIX+"/auth/register",
             PREFIX+"/auth/login",
+            PREFIX+"/auth/social-login",
             PREFIX+"/guest-users/**",
             PREFIX+"/user/unregistered-token",
             PREFIX+"/v3/api-docs/**",

--- a/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/swmStrong/demo/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.config.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.util.token.TokenType;
 import com.swmStrong.demo.util.token.TokenUtil;
 import com.swmStrong.demo.util.token.dto.TokenResponseDto;

--- a/src/main/java/com/swmStrong/demo/domain/common/enums/PeriodType.java
+++ b/src/main/java/com/swmStrong/demo/domain/common/enums/PeriodType.java
@@ -1,0 +1,5 @@
+package com.swmStrong.demo.domain.common.enums;
+
+public enum PeriodType {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/src/main/java/com/swmStrong/demo/domain/common/enums/Role.java
+++ b/src/main/java/com/swmStrong/demo/domain/common/enums/Role.java
@@ -1,4 +1,4 @@
-package com.swmStrong.demo.domain.global;
+package com.swmStrong.demo.domain.common.enums;
 
 public enum Role {
     UNREGISTERED, USER, ADMIN;

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
@@ -1,0 +1,48 @@
+package com.swmStrong.demo.domain.leaderboard.entity;
+
+import com.swmStrong.demo.domain.common.entity.BaseEntity;
+import com.swmStrong.demo.domain.common.enums.PeriodType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "leaderboard",
+        indexes = {
+                @Index(name="idx_category_period", columnList="categoryId, periodType, periodKey")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Leaderboard extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    private String userId;
+
+    private String categoryId;
+
+    @Enumerated(EnumType.STRING)
+    private PeriodType periodType;
+
+    private String periodKey;
+
+    private Integer rank;
+
+    private double score;
+
+    @Builder()
+    public Leaderboard(String userId, String categoryId, PeriodType periodType, String periodKey, Integer rank, double score) {
+        this.id = UUID.randomUUID().toString();
+        this.userId = userId;
+        this.categoryId = categoryId;
+        this.periodType = periodType;
+        this.periodKey = periodKey;
+        this.rank = rank;
+        this.score = score;
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
@@ -35,7 +35,7 @@ public class Leaderboard extends BaseEntity {
 
     private double score;
 
-    @Builder()
+    @Builder
     public Leaderboard(String userId, String categoryId, PeriodType periodType, String periodKey, Integer rank, double score) {
         this.id = UUID.randomUUID().toString();
         this.userId = userId;

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/entity/Leaderboard.java
@@ -1,12 +1,12 @@
 package com.swmStrong.demo.domain.leaderboard.entity;
 
-import com.swmStrong.demo.domain.common.entity.BaseEntity;
 import com.swmStrong.demo.domain.common.enums.PeriodType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -17,9 +17,8 @@ import java.util.UUID;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Leaderboard extends BaseEntity {
+public class Leaderboard {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     private String userId;
@@ -31,18 +30,21 @@ public class Leaderboard extends BaseEntity {
 
     private String periodKey;
 
-    private Integer rank;
+    private Integer ranking;
 
     private double score;
 
+    private LocalDateTime createdAt;
+
     @Builder
-    public Leaderboard(String userId, String categoryId, PeriodType periodType, String periodKey, Integer rank, double score) {
+    public Leaderboard(String userId, String categoryId, PeriodType periodType, String periodKey, Integer ranking, double score) {
         this.id = UUID.randomUUID().toString();
         this.userId = userId;
         this.categoryId = categoryId;
         this.periodType = periodType;
         this.periodKey = periodKey;
-        this.rank = rank;
+        this.ranking = ranking;
         this.score = score;
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardCache.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardCache.java
@@ -5,7 +5,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.Set;
 
-public interface LeaderboardRepository {
+public interface LeaderboardCache {
     void increaseScoreByUserId(String key, String userId, double seconds);
     Set<ZSetOperations.TypedTuple<String>> findPageWithSize(String key, int page, int size);
     Long findRankByUserId(String key, String userId);

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardCacheImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardCacheImpl.java
@@ -8,11 +8,11 @@ import java.util.Collections;
 import java.util.Set;
 
 @Repository
-public class LeaderboardRepositoryImpl implements LeaderboardRepository {
+public class LeaderboardCacheImpl implements LeaderboardCache {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public LeaderboardRepositoryImpl(StringRedisTemplate stringRedisTemplate) {
+    public LeaderboardCacheImpl(StringRedisTemplate stringRedisTemplate) {
         this.stringRedisTemplate = stringRedisTemplate;
     }
 

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/repository/LeaderboardRepository.java
@@ -1,0 +1,8 @@
+package com.swmStrong.demo.domain.leaderboard.repository;
+
+import com.swmStrong.demo.domain.leaderboard.entity.Leaderboard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LeaderboardRepository extends JpaRepository<Leaderboard, String> {
+
+}

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/scheduler/LeaderboardSyncScheduler.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/scheduler/LeaderboardSyncScheduler.java
@@ -1,0 +1,88 @@
+package com.swmStrong.demo.domain.leaderboard.scheduler;
+
+import com.swmStrong.demo.common.exception.ApiException;
+import com.swmStrong.demo.common.exception.code.ErrorCode;
+import com.swmStrong.demo.domain.common.enums.PeriodType;
+import com.swmStrong.demo.domain.leaderboard.entity.Leaderboard;
+import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.swmStrong.demo.domain.leaderboard.service.LeaderboardServiceImpl.LEADERBOARD_KEY_PREFIX;
+
+@Service
+public class LeaderboardSyncScheduler {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final LeaderboardRepository leaderboardRepository;
+
+    public LeaderboardSyncScheduler(
+            StringRedisTemplate stringRedisTemplate,
+            LeaderboardRepository leaderboardRepository
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.leaderboardRepository = leaderboardRepository;
+    }
+
+    @Scheduled(cron = "0 0 3 * * ?")
+    @Transactional
+    public void syncLeaderboard() {
+        Set<String> keys = stringRedisTemplate.keys(LEADERBOARD_KEY_PREFIX+":*");
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        List<Leaderboard> leaderboards = new ArrayList<>();
+        for (String key: keys) {
+            String[] parts = key.split(":");
+            String categoryId = parts[1];
+            String periodKey = parts[2];
+            PeriodType periodType = resolvePeriodType(periodKey);
+
+            Set<ZSetOperations.TypedTuple<String>> rankings = stringRedisTemplate.opsForZSet().rangeWithScores(key, 0, -1);
+
+            stringRedisTemplate.delete(key);
+
+            if (rankings == null || rankings.isEmpty()) {
+                continue;
+            }
+
+            int rank = 1;
+            for (ZSetOperations.TypedTuple<String> ranking : rankings) {
+                String userId = ranking.getValue();
+                double score = Optional.ofNullable(ranking.getScore()).orElse(0.0);
+
+                leaderboards.add(
+                        Leaderboard.builder()
+                                .userId(userId)
+                                .categoryId(categoryId)
+                                .periodType(periodType)
+                                .periodKey(periodKey)
+                                .rank(rank++)
+                                .score(score)
+                                .build()
+                );
+            }
+        }
+        leaderboardRepository.saveAll(leaderboards);
+    }
+
+    private PeriodType resolvePeriodType(String periodKey) {
+        if (periodKey.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            return PeriodType.DAILY;
+        } else if (periodKey.contains("W")) {
+            return PeriodType.WEEKLY;
+        } else if (periodKey.contains("M")) {
+            return PeriodType.MONTHLY;
+        }
+        throw new ApiException(ErrorCode.PERIOD_KEY_ERROR);
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -22,7 +22,7 @@ public class LeaderboardServiceImpl implements LeaderboardService {
     private final UserInfoProvider userInfoProvider;
     private final CategoryProvider categoryProvider;
 
-    private static final String LEADERBOARD_KEY_PREFIX = "leaderboard:";
+    private static final String LEADERBOARD_KEY_PREFIX = "leaderboard";
 
     public LeaderboardServiceImpl(
             LeaderboardRepository leaderboardRepository,

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.leaderboard.service;
 
 import com.swmStrong.demo.domain.categoryPattern.facade.CategoryProvider;
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
-import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardRepository;
+import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardCache;
 import com.swmStrong.demo.domain.user.facade.UserInfoProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
@@ -18,18 +18,18 @@ import java.util.*;
 @Service
 public class LeaderboardServiceImpl implements LeaderboardService {
 
-    private final LeaderboardRepository leaderboardRepository;
+    private final LeaderboardCache leaderboardCache;
     private final UserInfoProvider userInfoProvider;
     private final CategoryProvider categoryProvider;
 
-    private static final String LEADERBOARD_KEY_PREFIX = "leaderboard";
+    public static final String LEADERBOARD_KEY_PREFIX = "leaderboard";
 
     public LeaderboardServiceImpl(
-            LeaderboardRepository leaderboardRepository,
+            LeaderboardCache leaderboardCache,
             UserInfoProvider userInfoProvider,
             CategoryProvider categoryProvider
     ) {
-        this.leaderboardRepository = leaderboardRepository;
+        this.leaderboardCache = leaderboardCache;
         this.userInfoProvider = userInfoProvider;
         this.categoryProvider = categoryProvider;
     }
@@ -42,13 +42,13 @@ public class LeaderboardServiceImpl implements LeaderboardService {
 
         String dailyKey = generateDailyKey(category, day);
         log.info("Increase score for user {} to {} for daily", userId, duration);
-        leaderboardRepository.increaseScoreByUserId(dailyKey, userId, duration);
+        leaderboardCache.increaseScoreByUserId(dailyKey, userId, duration);
         String weeklyKey = generateWeeklyKey(category, day);
         log.info("Increase score for user {} to {} for weekly", userId, duration);
-        leaderboardRepository.increaseScoreByUserId(weeklyKey, userId, duration);
+        leaderboardCache.increaseScoreByUserId(weeklyKey, userId, duration);
         String monthlyKey = generateMonthlyKey(category, day);
         log.info("Increase score for user {} to {} for monthly", userId, duration);
-        leaderboardRepository.increaseScoreByUserId(monthlyKey, userId, duration);
+        leaderboardCache.increaseScoreByUserId(monthlyKey, userId, duration);
     }
 
     @Override
@@ -92,8 +92,8 @@ public class LeaderboardServiceImpl implements LeaderboardService {
         return LeaderboardResponseDto.builder()
                 .userId(userId)
                 .nickname(userInfoProvider.loadNicknameByUserId(userId))
-                .score(leaderboardRepository.findScoreByUserId(key, userId))
-                .rank(leaderboardRepository.findRankByUserId(key, userId) + 1)
+                .score(leaderboardCache.findScoreByUserId(key, userId))
+                .rank(leaderboardCache.findRankByUserId(key, userId) + 1)
                 .build();
     }
 
@@ -104,7 +104,7 @@ public class LeaderboardServiceImpl implements LeaderboardService {
         }
 
         String key = generateDailyKey(category, date);
-        Set<ZSetOperations.TypedTuple<String>> tuples = leaderboardRepository.findAll(key);
+        Set<ZSetOperations.TypedTuple<String>> tuples = leaderboardCache.findAll(key);
 
         Map<String, String> userNicknames = userInfoProvider.loadNicknamesByUserIds(
                 tuples.stream()
@@ -160,7 +160,7 @@ public class LeaderboardServiceImpl implements LeaderboardService {
     }
 
     private List<LeaderboardResponseDto> getPageByKey(String key, int page, int size) {
-        Set<ZSetOperations.TypedTuple<String>> tuples = leaderboardRepository.findPageWithSize(key, page, size);
+        Set<ZSetOperations.TypedTuple<String>> tuples = leaderboardCache.findPageWithSize(key, page, size);
 
         Map<String, String> userNicknames = userInfoProvider.loadNicknamesByUserIds(
                 tuples.stream()

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/controller/LoginCredentialController.java
@@ -5,6 +5,7 @@ import com.swmStrong.demo.common.response.ApiResponse;
 import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.loginCredential.dto.LoginRequestDto;
+import com.swmStrong.demo.domain.loginCredential.dto.SocialLoginRequestDto;
 import com.swmStrong.demo.domain.loginCredential.dto.UpgradeRequestDto;
 import com.swmStrong.demo.domain.loginCredential.service.LoginCredentialService;
 import com.swmStrong.demo.util.token.dto.RefreshTokenRequestDto;
@@ -81,6 +82,22 @@ public class LoginCredentialController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout() {
         return CustomResponseEntity.of(SuccessCode._OK);
+    }
+
+    @Operation(
+            summary = "소셜 로그인",
+            description =
+                "<p> supabase에서 받아온 토큰을 기반으로 로그인한다. </p>" +
+                "<p> 1. supabase에서 받아온 socialId가 이미 연동되어 있으면 바로 로그인한다. </p>" +
+                "<p> 2. supabase에서 가져온 이메일이 이미 우리 서버에 등록되어 있으면 그 아이디와 연동한다. </p>" +
+                "<p> 3. 신규유저의 경우 새로 아이디를 만들어 준다. //TODO: 이 경우 일반 로그인은 불가능하게 처리한다. </p>"
+    )
+    @PostMapping("/social-login")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> socialLogin(HttpServletRequest request, @RequestBody SocialLoginRequestDto socialLoginRequestDto) {
+        return CustomResponseEntity.of(
+                SuccessCode._OK,
+                loginCredentialService.socialLogin(request, socialLoginRequestDto)
+        );
     }
 }
 

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/dto/SocialLoginRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/dto/SocialLoginRequestDto.java
@@ -1,0 +1,6 @@
+package com.swmStrong.demo.domain.loginCredential.dto;
+
+public record SocialLoginRequestDto(
+        String accessToken
+) {
+}

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/entity/LoginCredential.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/entity/LoginCredential.java
@@ -1,12 +1,17 @@
 package com.swmStrong.demo.domain.loginCredential.entity;
 
+import com.swmStrong.demo.domain.common.enums.Role;
+import com.swmStrong.demo.domain.user.dto.UserRequestDto;
 import com.swmStrong.demo.domain.user.entity.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -18,6 +23,12 @@ public class LoginCredential extends User {
 
     private String password;
 
+    // 소셜로 시작한 경우 true로, 이 때 일반 로그인이 아예 되지 않도록 막기
+    @Column(name = "is_social", nullable = false, columnDefinition = "BOOLEAN DEFAULT 0")
+    private boolean isSocial;
+
+    private String socialId;
+
     private void setUser(User user) {
         this.id = user.getId();
         this.nickname = user.getNickname();
@@ -28,5 +39,31 @@ public class LoginCredential extends User {
         setUser(user);
         this.email = email;
         this.password = password;
+        this.isSocial = false;
+        this.updateRole(Role.USER);
+    }
+
+    private void setSocial() {
+        this.isSocial = true;
+    }
+
+    private void setSocialId(String socialId) {
+        this.socialId = socialId;
+    }
+
+    public LoginCredential connectSocialAccount(String socialId) {
+        this.setSocialId(socialId);
+        this.updateRole(Role.USER);
+        return this;
+    }
+
+    public static LoginCredential createSocialLoginCredential(String email, String socialId) {
+        LoginCredential loginCredential = LoginCredential.builder()
+                .user(User.of(UserRequestDto.of(UUID.randomUUID().toString(), "")))
+                .email(email)
+                .build();
+        loginCredential.setSocial();
+        loginCredential.setSocialId(socialId);
+        return loginCredential;
     }
 }

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProvider.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProvider.java
@@ -1,7 +1,7 @@
 package com.swmStrong.demo.domain.loginCredential.facade;
 
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 public interface LoginCredentialProvider {

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/facade/LoginCredentialProviderImpl.java
@@ -1,7 +1,7 @@
 package com.swmStrong.demo.domain.loginCredential.facade;
 
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.loginCredential.entity.LoginCredential;
 import com.swmStrong.demo.domain.loginCredential.repository.LoginCredentialRepository;
 import org.springframework.security.authentication.BadCredentialsException;

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/repository/LoginCredentialRepository.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/repository/LoginCredentialRepository.java
@@ -15,4 +15,5 @@ public interface LoginCredentialRepository extends JpaRepository<LoginCredential
     @Query(value = "INSERT INTO login_credential (id, email, password) VALUES (:id, :email, :password)", nativeQuery = true)
     void insertLoginCredential(@Param("id") String id, @Param("email") String email, @Param("password") String password);
 
+    Optional<LoginCredential> findBySocialId(String socialId);
 }

--- a/src/main/java/com/swmStrong/demo/domain/loginCredential/service/LoginCredentialService.java
+++ b/src/main/java/com/swmStrong/demo/domain/loginCredential/service/LoginCredentialService.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.domain.loginCredential.service;
 
+import com.swmStrong.demo.domain.loginCredential.dto.SocialLoginRequestDto;
 import com.swmStrong.demo.domain.loginCredential.dto.UpgradeRequestDto;
 import com.swmStrong.demo.util.token.dto.RefreshTokenRequestDto;
 import com.swmStrong.demo.util.token.dto.TokenResponseDto;
@@ -8,4 +9,5 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface LoginCredentialService {
     void upgradeToUser(UpgradeRequestDto upgradeRequestDto);
     TokenResponseDto tokenRefresh(String userId, HttpServletRequest request, RefreshTokenRequestDto refreshTokenRequestDto);
+    TokenResponseDto socialLogin(HttpServletRequest request, SocialLoginRequestDto socialLoginRequestDto);
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/dto/UserRequestDto.java
@@ -4,4 +4,7 @@ public record UserRequestDto(
         String userId,
         String nickname
 ) {
+    public static UserRequestDto of(String userId, String nickname) {
+        return new UserRequestDto(userId, nickname);
+    }
 }

--- a/src/main/java/com/swmStrong/demo/domain/user/entity/User.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/entity/User.java
@@ -1,7 +1,7 @@
 package com.swmStrong.demo.domain.user.entity;
 
 import com.swmStrong.demo.domain.common.entity.BaseEntity;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.user.dto.UserRequestDto;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/swmStrong/demo/domain/user/facade/UserUpdateProviderImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/facade/UserUpdateProviderImpl.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.user.facade;
 
 import com.swmStrong.demo.common.exception.ApiException;
 import com.swmStrong.demo.common.exception.code.ErrorCode;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.user.entity.User;
 import com.swmStrong.demo.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/user/service/UserServiceImpl.java
@@ -2,7 +2,7 @@ package com.swmStrong.demo.domain.user.service;
 
 import com.swmStrong.demo.common.exception.ApiException;
 import com.swmStrong.demo.common.exception.code.ErrorCode;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.user.dto.UnregisteredRequestDto;
 import com.swmStrong.demo.domain.user.dto.UserRequestDto;
 import com.swmStrong.demo.domain.user.dto.UserResponseDto;

--- a/src/main/java/com/swmStrong/demo/util/token/TokenType.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenType.java
@@ -15,9 +15,6 @@ public enum TokenType {
 
     @Override
     public String toString() {
-        return switch (this) {
-            case accessToken -> "accessToken";
-            case refreshToken -> "refreshToken";
-        };
+        return this.name();
     }
 }

--- a/src/main/java/com/swmStrong/demo/util/token/TokenType.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum TokenType {
     accessToken((long) (60 * 60)),          // 60sec * 60min
-    refreshToken((long) (60 * 60 * 24));    // 60sec * 60min * 24hour
+    refreshToken(-1L);
 
     private final Long expireTime;
 

--- a/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
@@ -1,7 +1,7 @@
 package com.swmStrong.demo.util.token;
 
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
-import com.swmStrong.demo.domain.global.Role;
+import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.loginCredential.facade.LoginCredentialProvider;
 import com.swmStrong.demo.domain.user.facade.UserDetailsProvider;
 import com.swmStrong.demo.util.redis.RedisUtil;

--- a/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
@@ -195,4 +195,18 @@ public class TokenUtil {
         }
         return false;
     }
+
+    public String loadSubjectByToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return claims.getSubject();
+        } catch (Exception e) {
+            throw new ApiException(ErrorCode._INVALID_TOKEN);
+        }
+    }
 }

--- a/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
@@ -8,6 +8,7 @@ import com.swmStrong.demo.domain.loginCredential.facade.LoginCredentialProvider;
 import com.swmStrong.demo.domain.user.facade.UserDetailsProvider;
 import com.swmStrong.demo.util.redis.RedisUtil;
 import com.swmStrong.demo.util.token.dto.RefreshTokenRequestDto;
+import com.swmStrong.demo.util.token.dto.SubjectResponseDto;
 import com.swmStrong.demo.util.token.dto.TokenResponseDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -196,7 +197,7 @@ public class TokenUtil {
         return false;
     }
 
-    public String loadSubjectByToken(String token) {
+    public SubjectResponseDto loadSubjectByToken(String token) {
         try {
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(getKey())
@@ -204,8 +205,9 @@ public class TokenUtil {
                     .parseClaimsJws(token)
                     .getBody();
 
-            return claims.getSubject();
+            return SubjectResponseDto.of(claims.getSubject(), claims.get("email", String.class));
         } catch (Exception e) {
+            log.error(e.getMessage());
             throw new ApiException(ErrorCode._INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
+++ b/src/main/java/com/swmStrong/demo/util/token/TokenUtil.java
@@ -1,5 +1,7 @@
 package com.swmStrong.demo.util.token;
 
+import com.swmStrong.demo.common.exception.ApiException;
+import com.swmStrong.demo.common.exception.code.ErrorCode;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.common.enums.Role;
 import com.swmStrong.demo.domain.loginCredential.facade.LoginCredentialProvider;
@@ -11,6 +13,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -125,7 +128,7 @@ public class TokenUtil {
             String userAgent
     ) throws RuntimeException {
         if (!isTokenValid(userId, refreshTokenRequestDto, userAgent)) {
-            throw new RuntimeException("토큰이 유효하지 않습니다.");
+            throw new ApiException(ErrorCode._INVALID_TOKEN);
         }
         Role role = loginCredentialProvider.loadRoleByUserId(userId);
 
@@ -170,7 +173,7 @@ public class TokenUtil {
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal, null, authority);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } else {
-            throw new RuntimeException("인증 과정에서 문제가 발생했습니다.");
+            throw new BadCredentialsException("인증 과정 중 문제가 발생했습니다.");
         }
     }
 

--- a/src/main/java/com/swmStrong/demo/util/token/dto/SubjectResponseDto.java
+++ b/src/main/java/com/swmStrong/demo/util/token/dto/SubjectResponseDto.java
@@ -1,0 +1,10 @@
+package com.swmStrong.demo.util.token.dto;
+
+public record SubjectResponseDto(
+        String supabaseId,
+        String email
+) {
+    public static SubjectResponseDto of(String supabaseId, String email) {
+        return new SubjectResponseDto(supabaseId, email);
+    }
+}


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [x] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.

- supabase 토큰 기반 소셜 로그인
- 리더보드 엔티티 및 스케쥴러

---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- supabase에서 발급한 토큰을 파싱, 내부의 데이터를 꺼내 서버에 저장하는 로직을 만들었습니다.
- supabase의 email과 매칭하여 우리 서버에 이미 가입된 이메일이 있는 경우 그 아이디에 연동하고, 그렇지 않은 경우 새로 계정을 발급합니다.

- 리더보드는 히스토리를 저장합니다. 
- 스케쥴러를 통해 매일 3시에 redis의 sorted set을 읽고, DB로 이관하는 작업을 수행합니다.

- 기타 리팩토링 작업을 수행했습니다.


---

## ⏰ 리뷰 시간 예상

- 약 15분 정도 예상됩니다.

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈

#53 supabase 소셜 로그인 회원 서버에 저장 
#15 리더보드 엔티티 및 스케쥴러 