### PR TITLE
[SWM-344] 데이터 파이프라인 redis batch 로 개선

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardService.java
@@ -2,6 +2,7 @@ package com.swmStrong.demo.domain.leaderboard.service;
 
 import com.swmStrong.demo.domain.common.enums.PeriodType;
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
+import com.swmStrong.demo.message.dto.LeaderBoardUsageMessage;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 
 public interface LeaderboardService {
     void increaseScore(String categoryId, String userId, double duration, double timestamp);
+    void increaseScoreBatch(List<LeaderBoardUsageMessage> messages);
     List<LeaderboardResponseDto> getLeaderboardPage(String category, int page, int size, LocalDate date, PeriodType periodType);
     LeaderboardResponseDto getUserScoreInfo(String category, String userId, LocalDate date, PeriodType periodType);
     Map<String, List<LeaderboardResponseDto>> getLeaderboards();

--- a/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/leaderboard/service/LeaderboardServiceImpl.java
@@ -8,13 +8,16 @@ import com.swmStrong.demo.domain.leaderboard.dto.CategoryDetailDto;
 import com.swmStrong.demo.domain.leaderboard.dto.LeaderboardResponseDto;
 import com.swmStrong.demo.domain.leaderboard.repository.LeaderboardCache;
 import com.swmStrong.demo.domain.user.facade.UserInfoProvider;
+import com.swmStrong.demo.message.dto.LeaderBoardUsageMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.WeekFields;
 import java.util.*;
 
@@ -50,6 +53,52 @@ public class LeaderboardServiceImpl implements LeaderboardService {
         increaseScoreByCategoryAndUserId(category, userId, day, duration);
         if (workCategories.contains(category)) {
             increaseScoreByCategoryAndUserId("work", userId, day, duration);
+        }
+    }
+
+    @Override
+    public void increaseScoreBatch(List<LeaderBoardUsageMessage> messages) {
+        Map<String, Map<String, Double>> categoryUserScoreMap = new HashMap<>();
+        Map<String, Double> workUserScoreMap = new HashMap<>();
+        
+        for (LeaderBoardUsageMessage message : messages) {
+            LocalDate day = LocalDateTime.ofInstant(Instant.ofEpochSecond((long) message.timestamp()),
+                    ZoneId.systemDefault()).toLocalDate();
+            ObjectId categoryObjectId = new ObjectId(message.categoryId());
+            String category = categoryProvider.getCategoryById(categoryObjectId);
+            
+            String dailyKey = generateDailyKey(category, day);
+            String weeklyKey = generateWeeklyKey(category, day);
+            String monthlyKey = generateMonthlyKey(category, day);
+            
+            categoryUserScoreMap.computeIfAbsent(dailyKey, k -> new HashMap<>())
+                    .merge(message.userId(), message.duration(), Double::sum);
+            categoryUserScoreMap.computeIfAbsent(weeklyKey, k -> new HashMap<>())
+                    .merge(message.userId(), message.duration(), Double::sum);
+            categoryUserScoreMap.computeIfAbsent(monthlyKey, k -> new HashMap<>())
+                    .merge(message.userId(), message.duration(), Double::sum);
+            
+            if (workCategories.contains(category)) {
+                String workDailyKey = generateDailyKey("work", day);
+                String workWeeklyKey = generateWeeklyKey("work", day);
+                String workMonthlyKey = generateMonthlyKey("work", day);
+                
+                categoryUserScoreMap.computeIfAbsent(workDailyKey, k -> new HashMap<>())
+                        .merge(message.userId(), message.duration(), Double::sum);
+                categoryUserScoreMap.computeIfAbsent(workWeeklyKey, k -> new HashMap<>())
+                        .merge(message.userId(), message.duration(), Double::sum);
+                categoryUserScoreMap.computeIfAbsent(workMonthlyKey, k -> new HashMap<>())
+                        .merge(message.userId(), message.duration(), Double::sum);
+            }
+        }
+        
+        for (Map.Entry<String, Map<String, Double>> keyEntry : categoryUserScoreMap.entrySet()) {
+            String key = keyEntry.getKey();
+            Map<String, Double> userScoreMap = keyEntry.getValue();
+            log.info("key: {}, userScoreMap: {}", key, userScoreMap);
+            for (Map.Entry<String, Double> userEntry : userScoreMap.entrySet()) {
+                leaderboardCache.increaseScoreByUserId(key, userEntry.getKey(), userEntry.getValue());
+            }
         }
     }
 

--- a/src/main/java/com/swmStrong/demo/infra/redis/stream/RedisStreamProducer.java
+++ b/src/main/java/com/swmStrong/demo/infra/redis/stream/RedisStreamProducer.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -23,5 +24,15 @@ public class RedisStreamProducer {
         Map<String, String> body = objectMapper.convertValue(dto, new TypeReference<>() {});
         stringRedisTemplate.opsForStream()
                 .add(MapRecord.create(streamKey, body));
+    }
+
+    public <T> void sendBatch(String streamKey, List<T> dtos) {
+        stringRedisTemplate.executePipelined((org.springframework.data.redis.core.RedisCallback<Object>) connection -> {
+            for (T dto : dtos) {
+                Map<String, String> body = objectMapper.convertValue(dto, new TypeReference<>() {});
+                stringRedisTemplate.opsForStream().add(MapRecord.create(streamKey, body));
+            }
+            return null;
+        });
     }
 }


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [ ] 신규 기능
- [x] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
- 데이터 파이프라인 redis batch로 개선
---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 기존의 데이터 파이프라인에서 중복된 N+1 문제로 인해 낮은 성능을 보이고 있었습니다.
- 특히 네트워크 요청이 몰리게 되면 과도한 레디스 참조로 인해 레디스 연결이 불안정 해집니다.
- 이를 개선하기 위해 요청 수를 O(1) 수준으로 줄이는 작업을 진행했습니다. 
---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈
> 예: Close #1, Fix #42