### PR TITLE
[SWM-351] session 롱 폴링을 통해 반환

### DIFF
--- a/src/main/java/com/swmStrong/demo/common/response/CustomDeferredResult.java
+++ b/src/main/java/com/swmStrong/demo/common/response/CustomDeferredResult.java
@@ -1,0 +1,82 @@
+package com.swmStrong.demo.common.response;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.function.Consumer;
+
+@Slf4j
+public class CustomDeferredResult<T> {
+    
+    private static final long DEFAULT_TIMEOUT_MS = 30000L; // 30초 기본 타임아웃
+    
+    private final DeferredResult<T> deferredResult;
+    private final String identifier;
+    
+    public CustomDeferredResult(String identifier) {
+        this(identifier, DEFAULT_TIMEOUT_MS);
+    }
+    
+    public CustomDeferredResult(String identifier, long timeoutMs) {
+        this.identifier = identifier;
+        this.deferredResult = new DeferredResult<>(timeoutMs);
+        
+        this.deferredResult.onTimeout(() -> {
+            log.debug("DeferredResult timeout for: {}", identifier);
+            this.deferredResult.setResult(null);
+        });
+        
+        this.deferredResult.onCompletion(() -> 
+            log.debug("DeferredResult completed for: {}", identifier)
+        );
+        
+        this.deferredResult.onError(throwable -> 
+            log.error("DeferredResult error for: {}", identifier, throwable)
+        );
+    }
+    
+    public boolean setResult(T result) {
+        return deferredResult.setResult(result);
+    }
+    
+    public void onTimeout(Runnable callback) {
+        deferredResult.onTimeout(callback);
+    }
+    
+    public void onCompletion(Runnable callback) {
+        deferredResult.onCompletion(callback);
+    }
+    
+    public void onError(Consumer<Throwable> callback) {
+        deferredResult.onError(callback);
+    }
+    
+    public DeferredResult<T> getDeferredResult() {
+        return deferredResult;
+    }
+    
+    public <R> DeferredResult<R> map(java.util.function.Function<T, R> mapper) {
+        DeferredResult<R> mappedResult = new DeferredResult<>(DEFAULT_TIMEOUT_MS);
+        
+        // 기존 결과 핸들러 설정
+        deferredResult.setResultHandler(result -> {
+            if (result != null) {
+                mappedResult.setResult(mapper.apply((T) result));
+            } else {
+                mappedResult.setResult(null);
+            }
+        });
+        
+        // 타임아웃 전파
+        deferredResult.onTimeout(() -> mappedResult.setResult(null));
+        
+        // 에러 전파
+        deferredResult.onError(throwable -> mappedResult.setErrorResult(throwable));
+        
+        return mappedResult;
+    }
+    
+    public String getIdentifier() {
+        return identifier;
+    }
+}

--- a/src/main/java/com/swmStrong/demo/config/cors/WebConfig.java
+++ b/src/main/java/com/swmStrong/demo/config/cors/WebConfig.java
@@ -1,5 +1,6 @@
 package com.swmStrong.demo.config.cors;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -12,4 +13,5 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(false);
     }
+    
 }

--- a/src/main/java/com/swmStrong/demo/config/security/AsyncSecurityConfig.java
+++ b/src/main/java/com/swmStrong/demo/config/security/AsyncSecurityConfig.java
@@ -1,0 +1,37 @@
+package com.swmStrong.demo.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.concurrent.DelegatingSecurityContextCallable;
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncSecurityConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setDefaultTimeout(30000L);
+        configurer.setTaskExecutor(getAsyncExecutor());
+    }
+
+    @Bean(name = "securityAsyncExecutor")
+    public DelegatingSecurityContextAsyncTaskExecutor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("SecurityAsync-");
+        executor.initialize();
+        
+        return new DelegatingSecurityContextAsyncTaskExecutor(executor);
+    }
+}

--- a/src/main/java/com/swmStrong/demo/config/security/SecurityConfig.java
+++ b/src/main/java/com/swmStrong/demo/config/security/SecurityConfig.java
@@ -92,6 +92,10 @@ public class SecurityConfig {
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
+                // 비동기 처리 지원 활성화
+                .securityContext(securityContext -> securityContext
+                        .requireExplicitSave(false)
+                )
                 .addFilterBefore(tokenAuthorizationFilter, LogoutFilter.class)
                 .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(tokenAuthorizationFilter, BasicAuthenticationFilter.class)

--- a/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionLongPollingService.java
+++ b/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionLongPollingService.java
@@ -1,0 +1,61 @@
+package com.swmStrong.demo.domain.sessionScore.service;
+
+import com.swmStrong.demo.common.response.CustomDeferredResult;
+import com.swmStrong.demo.domain.sessionScore.dto.SessionScoreResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+public class SessionLongPollingService {
+    
+    private final SessionScoreService sessionScoreService;
+    private final SessionStateManager sessionStateManager;
+    private final SessionPollingManager sessionPollingManager;
+    
+    public SessionLongPollingService(
+            SessionScoreService sessionScoreService,
+            SessionStateManager sessionStateManager,
+            SessionPollingManager sessionPollingManager
+    ) {
+        this.sessionScoreService = sessionScoreService;
+        this.sessionStateManager = sessionStateManager;
+        this.sessionPollingManager = sessionPollingManager;
+    }
+    
+    public CustomDeferredResult<List<SessionScoreResponseDto>> getSessionScoreWithLongPolling(
+            String userId, LocalDate date) {
+        
+        String key = String.format("%s:%s", userId, date.toString());
+        CustomDeferredResult<List<SessionScoreResponseDto>> deferredResult = 
+                new CustomDeferredResult<>(key);
+        
+        // 먼저 현재 데이터를 확인해서 데이터가 없으면 바로 null 반환
+        List<SessionScoreResponseDto> currentData = sessionScoreService.getByUserIdAndSessionDate(userId, date);
+        if (currentData.isEmpty()) {
+            log.debug("No session data found, returning null immediately: {}", key);
+            deferredResult.setResult(List.of());
+            return deferredResult;
+        }
+        
+        // 모든 세션이 처리 완료되었는지 확인
+        boolean allSessionsProcessed = currentData.stream()
+                .allMatch(sessionScore -> sessionStateManager.isSessionProcessed(userId, date, sessionScore.session()));
+        
+        if (allSessionsProcessed) {
+            log.debug("All sessions processed, returning immediately: {}", key);
+            deferredResult.setResult(currentData);
+            return deferredResult;
+        }
+        
+        // 아직 처리 중인 세션이 있는 경우 대기 큐에 등록
+        log.debug("Sessions still processing, registering for long polling: {}", key);
+        sessionPollingManager.registerDeferredResult(userId, date, deferredResult);
+        
+        return deferredResult;
+    }
+    
+}

--- a/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionPollingManager.java
+++ b/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionPollingManager.java
@@ -1,0 +1,108 @@
+package com.swmStrong.demo.domain.sessionScore.service;
+
+import com.swmStrong.demo.common.response.CustomDeferredResult;
+import com.swmStrong.demo.domain.sessionScore.dto.SessionScoreResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class SessionPollingManager {
+    
+    private final Map<String, CustomDeferredResult<List<SessionScoreResponseDto>>> waitingRequests = new ConcurrentHashMap<>();
+    
+    public void registerDeferredResult(String userId, LocalDate date, int session, 
+                                       CustomDeferredResult<List<SessionScoreResponseDto>> deferredResult) {
+        String key = generateKey(userId, date, session);
+        
+        deferredResult.onCompletion(() -> {
+            log.debug("Long polling completed for key: {}", key);
+            waitingRequests.remove(key);
+        });
+        
+        deferredResult.onError(throwable -> {
+            log.error("Long polling error for key: {}", key, throwable);
+            waitingRequests.remove(key);
+        });
+        
+        waitingRequests.put(key, deferredResult);
+        log.debug("Registered long polling request for key: {}", key);
+    }
+    
+    public void registerDeferredResult(String userId, LocalDate date, 
+                                       CustomDeferredResult<List<SessionScoreResponseDto>> deferredResult) {
+        String key = generateKey(userId, date);
+        
+        deferredResult.onCompletion(() -> {
+            log.debug("Long polling completed for key: {}", key);
+            waitingRequests.remove(key);
+        });
+        
+        deferredResult.onError(throwable -> {
+            log.error("Long polling error for key: {}", key, throwable);
+            waitingRequests.remove(key);
+        });
+        
+        waitingRequests.put(key, deferredResult);
+        log.debug("Registered long polling request for key: {}", key);
+    }
+    
+    public void notifySessionProcessed(String userId, LocalDate date, int session, List<SessionScoreResponseDto> data) {
+        String sessionKey = generateKey(userId, date, session);
+        String dateKey = generateKey(userId, date);
+        
+        // 개별 세션 키에 대한 알림 (기존 호환성)
+        CustomDeferredResult<List<SessionScoreResponseDto>> sessionDeferredResult = waitingRequests.get(sessionKey);
+        if (sessionDeferredResult != null) {
+            boolean success = sessionDeferredResult.setResult(data);
+            if (success) {
+                log.debug("Notified waiting request for session key: {}", sessionKey);
+                waitingRequests.remove(sessionKey);
+            } else {
+                log.warn("Failed to set result for session key: {} (already set or expired)", sessionKey);
+            }
+        } else {
+            log.debug("No waiting request found for session key: {}", sessionKey);
+        }
+        
+    }
+    
+    public void notifyAllSessionsProcessed(String userId, LocalDate date, List<SessionScoreResponseDto> data) {
+        String dateKey = generateKey(userId, date);
+        
+        CustomDeferredResult<List<SessionScoreResponseDto>> dateDeferredResult = waitingRequests.get(dateKey);
+        if (dateDeferredResult != null) {
+            boolean success = dateDeferredResult.setResult(data);
+            if (success) {
+                log.debug("Notified all sessions processed for date key: {}", dateKey);
+                waitingRequests.remove(dateKey);
+            } else {
+                log.warn("Failed to set result for date key: {} (already set or expired)", dateKey);
+            }
+        } else {
+            log.debug("No waiting request found for date key: {}", dateKey);
+        }
+    }
+    
+    public boolean hasWaitingRequest(String userId, LocalDate date, int session) {
+        String key = generateKey(userId, date, session);
+        return waitingRequests.containsKey(key);
+    }
+    
+    private String generateKey(String userId, LocalDate date, int session) {
+        return String.format("%s:%s:%d", userId, date.toString(), session);
+    }
+    
+    private String generateKey(String userId, LocalDate date) {
+        return String.format("%s:%s", userId, date.toString());
+    }
+    
+    public int getWaitingRequestCount() {
+        return waitingRequests.size();
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionStateManager.java
+++ b/src/main/java/com/swmStrong/demo/domain/sessionScore/service/SessionStateManager.java
@@ -1,0 +1,46 @@
+package com.swmStrong.demo.domain.sessionScore.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+public class SessionStateManager {
+    
+    private static final String SESSION_PROCESSED_KEY_PREFIX = "session:processed:";
+    private static final Duration TTL = Duration.ofHours(24); // 24시간 후 자동 삭제
+    
+    private final StringRedisTemplate redisTemplate;
+    
+    public SessionStateManager(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+    
+    public void markSessionAsProcessed(String userId, LocalDate date, int session) {
+        String key = generateKey(userId, date, session);
+        redisTemplate.opsForValue().set(key, "true", TTL);
+        log.debug("Marked session as processed: {}", key);
+    }
+    
+    public boolean isSessionProcessed(String userId, LocalDate date, int session) {
+        String key = generateKey(userId, date, session);
+        String value = redisTemplate.opsForValue().get(key);
+        boolean processed = "true".equals(value);
+        log.debug("Session processed check for {}: {}", key, processed);
+        return processed;
+    }
+    
+    public void removeSessionProcessedFlag(String userId, LocalDate date, int session) {
+        String key = generateKey(userId, date, session);
+        redisTemplate.delete(key);
+        log.debug("Removed processed flag for: {}", key);
+    }
+    
+    private String generateKey(String userId, LocalDate date, int session) {
+        return SESSION_PROCESSED_KEY_PREFIX + userId + ":" + date.toString() + ":" + session;
+    }
+}

--- a/src/main/java/com/swmStrong/demo/message/event/SessionProcessedEvent.java
+++ b/src/main/java/com/swmStrong/demo/message/event/SessionProcessedEvent.java
@@ -1,0 +1,16 @@
+package com.swmStrong.demo.message.event;
+
+import com.swmStrong.demo.domain.sessionScore.dto.SessionScoreResponseDto;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record SessionProcessedEvent(
+        String userId,
+        int session,
+        LocalDate sessionDate,
+        List<SessionScoreResponseDto> sessionScores
+) {
+}


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [ ] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
- session 반환 롱폴링 기능 추가
---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- 롱폴링을 도입해 데이터가 모두 처리된 경우에만 반환할 수 있도록 했습니다.
- 일반적으로 10-15초 내외의 처리시간을 가지기 때문에, 최대 30초의 timeout을 가지도록 설정했습니다.
- 이를 통해 클라이언트에서 1번의 요청 이후 값이 온전한 경우 바로 반환할 수 있도록 로직을 개선합니다. 

---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈
> 예: Close #1, Fix #42